### PR TITLE
chore: backport CI link-check resilience + urllib3/idna deps bump from main

### DIFF
--- a/.github/scripts/lychee-gate.sh
+++ b/.github/scripts/lychee-gate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Parse the lychee markdown summary and fail the job only on real broken
+# links (4xx/5xx). Timeouts are reported as warnings, not failures, because
+# scholarly and government sites frequently throttle CI runner IPs even
+# when the URLs are valid in a browser.
+#
+# Usage:  lychee-gate.sh <path-to-lychee-report.md>
+
+set -euo pipefail
+
+report="${1:?usage: $0 <report.md>}"
+
+if [[ ! -f "$report" ]]; then
+  echo "::error::lychee report not found at $report"
+  exit 1
+fi
+
+# Extract counts from the lychee summary table. The relevant rows look like:
+#   | 🚫 Errors      | 0     |
+#   | ⏳ Timeouts    | 1     |
+errors=$(grep -E '🚫 Errors' "$report" | grep -oE '[0-9]+' | head -1 || true)
+timeouts=$(grep -E '⏳ Timeouts' "$report" | grep -oE '[0-9]+' | head -1 || true)
+errors="${errors:-0}"
+timeouts="${timeouts:-0}"
+
+echo "Lychee summary — Errors: ${errors}, Timeouts: ${timeouts}"
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "::error::${errors} real broken link(s) found — see job summary"
+  exit 1
+fi
+
+if [[ "$timeouts" -gt 0 ]]; then
+  echo "::warning::${timeouts} timeout(s) detected — treated as transient, not failed. See job summary."
+fi
+
+exit 0

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -63,7 +63,9 @@ jobs:
             --scheme https
             --max-concurrency 32
             --host-concurrency 4
-            --timeout 30
+            --timeout 60
+            --max-retries 2
+            --retry-wait-time 5
             --exclude-path '(^|/)\.git/'
             --exclude-path '(^|/)uv\.lock$'
             --preprocess .github/scripts/lychee-preprocess.py
@@ -103,7 +105,9 @@ jobs:
             --scheme https
             --max-concurrency 32
             --host-concurrency 4
-            --timeout 30
+            --timeout 60
+            --max-retries 2
+            --retry-wait-time 5
             --exclude-path '(^|/)\.git/'
             --exclude-path '(^|/)uv\.lock$'
             --preprocess .github/scripts/lychee-preprocess.py

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -52,6 +52,7 @@ jobs:
         run: chmod +x .github/scripts/lychee-preprocess.py
 
       - name: Check links
+        id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -71,9 +72,13 @@ jobs:
             --preprocess .github/scripts/lychee-preprocess.py
             --extensions md,ipynb,py,toml,yml,yaml,html,txt
             .
-          fail: true
+          fail: false
           format: markdown
+          output: ./lychee-report.md
           jobSummary: true
+
+      - name: Fail only on real broken links (not timeouts)
+        run: .github/scripts/lychee-gate.sh ./lychee-report.md
 
   check-scheduled-branches:
     if: github.event_name == 'schedule'
@@ -94,6 +99,7 @@ jobs:
         run: chmod +x .github/scripts/lychee-preprocess.py
 
       - name: Check links
+        id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -113,6 +119,10 @@ jobs:
             --preprocess .github/scripts/lychee-preprocess.py
             --extensions md,ipynb,py,toml,yml,yaml,html,txt
             .
-          fail: true
+          fail: false
           format: markdown
+          output: ./lychee-report.md
           jobSummary: true
+
+      - name: Fail only on real broken links (not timeouts)
+        run: .github/scripts/lychee-gate.sh ./lychee-report.md

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -54,3 +54,11 @@
 ^https://doi\.org/10\.1111/j\.1745-6584\.2005\.00052\.x$
 ^https://doi\.org/10\.1029/92WR00607$
 ^https://doi\.org/10\.1146/annurev-statistics-010814-020148$
+
+# Valid resource that times out from GitHub Actions runners (likely IP-based
+# throttling of the Azure range). Browser/local curl returns 200 OK quickly.
+# Manual-check at each major review:
+#   - https://scnat.ch/de/uuid/i/0bd7aa3b-0bd7-5d54-9e2f-597a42dada50-Die_Grundwasserverh%C3%A4ltnisse_des_Kantons_Z%C3%BCrich
+#       SCNAT/SAGW report on the groundwater conditions of canton Zürich
+#       → flow/2_perceptual_model.ipynb
+^https://scnat\.ch/de/uuid/i/0bd7aa3b-0bd7-5d54-9e2f-597a42dada50-Die_Grundwasserverh%C3%A4ltnisse_des_Kantons_Z%C3%BCrich$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -61,3 +61,10 @@
 #   - https://innovedumprojects.ethz.ch/projects/groundwater-in-action-real-world-problem-centered-approach-with-students-collaborative-projects/
 #       Innovedum project page for this course               → README.md
 ^https://innovedumprojects\.ethz\.ch/projects/groundwater-in-action-real-world-problem-centered-approach-with-students-collaborative-projects/$
+
+# Valid scholarly resource that returns 403 Forbidden to CI runner IPs
+# (bot-blocked). Browser returns 200 OK. Manual-check at each major review:
+#   - https://fc79.gw-project.org/english/
+#       Freeze & Cherry (1979) "Groundwater" via The Groundwater Project
+#                                                           → PROJECT/0_start_here.ipynb
+^https://fc79\.gw-project\.org/english/$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -54,11 +54,3 @@
 ^https://doi\.org/10\.1111/j\.1745-6584\.2005\.00052\.x$
 ^https://doi\.org/10\.1029/92WR00607$
 ^https://doi\.org/10\.1146/annurev-statistics-010814-020148$
-
-# Valid resource that times out from GitHub Actions runners (likely IP-based
-# throttling of the Azure range). Browser/local curl returns 200 OK quickly.
-# Manual-check at each major review:
-#   - https://scnat.ch/de/uuid/i/0bd7aa3b-0bd7-5d54-9e2f-597a42dada50-Die_Grundwasserverh%C3%A4ltnisse_des_Kantons_Z%C3%BCrich
-#       SCNAT/SAGW report on the groundwater conditions of canton Zürich
-#       → flow/2_perceptual_model.ipynb
-^https://scnat\.ch/de/uuid/i/0bd7aa3b-0bd7-5d54-9e2f-597a42dada50-Die_Grundwasserverh%C3%A4ltnisse_des_Kantons_Z%C3%BCrich$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -54,3 +54,10 @@
 ^https://doi\.org/10\.1111/j\.1745-6584\.2005\.00052\.x$
 ^https://doi\.org/10\.1029/92WR00607$
 ^https://doi\.org/10\.1146/annurev-statistics-010814-020148$
+
+# Valid ETH Zurich page that returns 415 Unsupported Media Type to
+# HEAD requests from CI runner IPs (Cloudflare/WAF bot-detection).
+# Browser/local curl returns 200 OK. Manual-check at each major review:
+#   - https://innovedumprojects.ethz.ch/projects/groundwater-in-action-real-world-problem-centered-approach-with-students-collaborative-projects/
+#       Innovedum project page for this course               → README.md
+^https://innovedumprojects\.ethz\.ch/projects/groundwater-in-action-real-world-problem-centered-approach-with-students-collaborative-projects/$

--- a/uv.lock
+++ b/uv.lock
@@ -998,11 +998,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -3218,11 +3218,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Backports 5 maintenance commits that landed on `main` (2026-05-28 via PRs #98 and #99) but were never propagated to `course_2026`. Closes the asymmetry where `main` had CI/deps fixes that `course_2026` lacked.

- **1 deps commit:** `urllib3 → 2.7.0`, `idna → 3.17` (was: 2.6.3 / 3.11 on course_2026)
- **4 CI commits:** Check Links resilience, lychee timeout handling, ignore-list additions for ETH Innovedum (Cloudflare bot-block) and scnat.ch (throttling)

All 5 commits cherry-picked from `main` with git auto-merge — no manual conflict resolution required.

## Commits cherry-picked (chronological)

| Original SHA | Title |
|---|---|
| `681880a` | deps: bump urllib3 to 2.7.0 and idna to 3.17 to close 3 dependabot alerts |
| `c537989` | ci: make Check Links resilient to transient timeouts |
| `cb19b3a` | ci: ignore scnat.ch URL that throttles GitHub Actions runners |
| `bb457b5` | ci: treat lychee timeouts as warnings, not failures |
| `f9036d3` | ci: ignore ETH Innovedum project URL (Cloudflare bot-blocks CI) |

## Files changed (4 files; +68 / −10)
- `.github/scripts/lychee-gate.sh` (new) — lychee gate script
- `.github/workflows/check-links.yml` — timeout + warning behavior
- `.lycheeignore` — ETH Innovedum + scnat entries (some scnat entries were already on course_2026 via Louise's `95c5eed` notebook rename, so the actual delta is smaller than the sum of individual commits)
- `uv.lock` — urllib3 + idna bumps (independent of the bleach/jupyter-server/tornado bumps from #102)

## Test plan
- [x] All 5 cherry-picks applied cleanly via git auto-merge
- [x] `uv sync` resolves 177 packages
- [x] Final lock has urllib3 2.7.0 / idna 3.17 alongside the existing bleach 6.4.0 / jupyter-server 2.20.0 / tornado 6.5.7 from #102
- [ ] CI passes on this branch (Check Notebook Dependencies, Check Links — this PR's CI run also exercises the resilience improvements being backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)