### PR TITLE
feat: add internal-link validator (phase 1 + 1.5)

### DIFF
--- a/PROJECT/workspace/template/case_study_flow_group_0.ipynb
+++ b/PROJECT/workspace/template/case_study_flow_group_0.ipynb
@@ -445,7 +445,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "[maps.zh.ch](maps.zh.ch) shows the concessioned pumping rates for our well group 210 (zoom into the area where your groups wells are located and look for your groops concession number). For the demo case, we look for b1-210 where b1 is the indicator for the Limmat valley aquifer and 210 is the concession number. Click on that number to see the concessioned pumping rates in the Info sidepane (Look for \"Konzessionierte Entnahmemenge [l/min]\"). In our case, the concessioned pumping rate is 1400 l/s. "
+    "[maps.zh.ch](https://maps.zh.ch) shows the concessioned pumping rates for our well group 210 (zoom into the area where your groups wells are located and look for your groops concession number). For the demo case, we look for b1-210 where b1 is the indicator for the Limmat valley aquifer and 210 is the concession number. Click on that number to see the concessioned pumping rates in the Info sidepane (Look for \"Konzessionierte Entnahmemenge [l/min]\"). In our case, the concessioned pumping rate is 1400 l/s. "
    ]
   },
   {

--- a/_SUPPORT/src/scripts/check_internal_links.py
+++ b/_SUPPORT/src/scripts/check_internal_links.py
@@ -1,0 +1,354 @@
+"""Validate tracked internal links in student-facing notebooks and Markdown.
+
+Notebook failure locations use 0-based cell indexes.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote
+
+
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(([^)\n]+)\)")
+FENCE_START_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+EXCLUDED_PREFIXES = (
+    "http://",
+    "https://",
+    "mailto:",
+    "tel:",
+    "ftp:",
+    "//",
+    "data:",
+)
+
+
+@dataclass(frozen=True)
+class ExtractedLink:
+    href: str
+    line: int
+
+
+@dataclass(frozen=True)
+class LinkFailure:
+    source: str
+    location: str
+    href: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    scanned_files: int
+    checked_links: int
+    failures: list[LinkFailure]
+
+
+class LinkHTMLParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = []
+
+    def handle_starttag(self, tag, attrs):
+        attr_name = None
+        if tag.lower() == "a":
+            attr_name = "href"
+        elif tag.lower() == "img":
+            attr_name = "src"
+
+        if attr_name is None:
+            return
+
+        for name, value in attrs:
+            if name.lower() == attr_name and value is not None:
+                line, _ = self.getpos()
+                self.links.append(ExtractedLink(value, line))
+                break
+
+
+def list_tracked_files(repo_root):
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip()
+    }
+
+
+def is_source_file(path):
+    path = path.replace("\\", "/")
+    suffix = Path(path).suffix.lower()
+
+    if "/" not in path and suffix == ".md":
+        return True
+
+    if not path.startswith("PROJECT/"):
+        return False
+
+    return suffix in {".ipynb", ".md"}
+
+
+def source_files(tracked_files):
+    return sorted(path for path in tracked_files if is_source_file(path))
+
+
+def strip_markdown_destination(raw_destination):
+    destination = raw_destination.strip()
+
+    if destination.startswith("<"):
+        end = destination.find(">")
+        if end != -1:
+            return destination[1:end].strip()
+
+    return destination.split(None, 1)[0] if destination else destination
+
+
+def blank_line_like(line):
+    return "\n" if line.endswith("\n") else ""
+
+
+def strip_fenced_code_blocks(text):
+    """Blank ``` and ~~~ fenced blocks; 4-space indented code is deferred."""
+    stripped_lines = []
+    in_fence = False
+    fence_char = ""
+    fence_length = 0
+
+    for line in text.splitlines(keepends=True):
+        if in_fence:
+            stripped_lines.append(blank_line_like(line))
+            candidate = line.rstrip("\n\r")
+            if re.match(
+                rf"^[ \t]{{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*$",
+                candidate,
+            ):
+                in_fence = False
+            continue
+
+        match = FENCE_START_RE.match(line)
+        if match:
+            fence = match.group(1)
+            in_fence = True
+            fence_char = fence[0]
+            fence_length = len(fence)
+            stripped_lines.append(blank_line_like(line))
+            continue
+
+        stripped_lines.append(line)
+
+    return "".join(stripped_lines)
+
+
+def extract_links(text):
+    text = strip_fenced_code_blocks(text)
+    links = []
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        line = text.count("\n", 0, match.start()) + 1
+        links.append(ExtractedLink(strip_markdown_destination(match.group(1)), line))
+
+    parser = LinkHTMLParser()
+    parser.feed(text)
+    links.extend(parser.links)
+    return links
+
+
+def should_skip_href(href):
+    stripped = href.strip()
+    lowered = stripped.lower()
+    return (
+        not stripped
+        or stripped.startswith("#")
+        or stripped.startswith("/")
+        or lowered.startswith(EXCLUDED_PREFIXES)
+    )
+
+
+def internal_path_from_href(href):
+    if should_skip_href(href):
+        return None
+
+    path_part = href.split("#", 1)[0].split("?", 1)[0]
+    if not path_part:
+        return None
+
+    return unquote(path_part)
+
+
+def validate_link(repo_root, tracked_files, source_path, href):
+    repo_root = Path(repo_root).resolve()
+    source_path = Path(source_path)
+    if not source_path.is_absolute():
+        source_path = repo_root / source_path
+
+    internal_path = internal_path_from_href(href)
+    if internal_path is None:
+        return None
+
+    resolved_target = (source_path.parent / internal_path).resolve()
+    try:
+        target_rel = resolved_target.relative_to(repo_root).as_posix()
+    except ValueError:
+        return "path escapes repo root"
+
+    if target_rel not in tracked_files:
+        return "target does not exist"
+
+    return None
+
+
+def markdown_source(source):
+    if isinstance(source, list):
+        return "".join(source)
+    if isinstance(source, str):
+        return source
+    return ""
+
+
+def validate_markdown_file(repo_root, tracked_files, source_rel):
+    source_path = repo_root / source_rel
+    text = source_path.read_text(encoding="utf-8")
+    failures = []
+    checked_links = 0
+
+    for link in extract_links(text):
+        internal_path = internal_path_from_href(link.href)
+        if internal_path is None:
+            continue
+
+        checked_links += 1
+        reason = validate_link(repo_root, tracked_files, source_path, link.href)
+        if reason is not None:
+            failures.append(LinkFailure(source_rel, str(link.line), link.href, reason))
+
+    return checked_links, failures
+
+
+def validate_notebook_file(repo_root, tracked_files, source_rel):
+    source_path = repo_root / source_rel
+    failures = []
+    checked_links = 0
+
+    try:
+        notebook = json.loads(source_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return 0, [LinkFailure(source_rel, "notebook", source_rel, f"unreadable notebook: {exc}")]
+    except json.JSONDecodeError as exc:
+        return 0, [
+            LinkFailure(
+                source_rel,
+                "notebook",
+                source_rel,
+                f"malformed notebook: {exc.msg}",
+            )
+        ]
+
+    cells = notebook.get("cells") if isinstance(notebook, dict) else None
+    if not isinstance(cells, list):
+        return 0, [
+            LinkFailure(
+                source_rel,
+                "notebook",
+                source_rel,
+                "malformed notebook: missing cells list",
+            )
+        ]
+
+    for cell_index, cell in enumerate(cells):
+        if not isinstance(cell, dict):
+            return 0, [
+                LinkFailure(
+                    source_rel,
+                    "notebook",
+                    source_rel,
+                    f"malformed notebook: cell {cell_index} is not an object",
+                )
+            ]
+
+        if cell.get("cell_type") != "markdown":
+            continue
+
+        for link in extract_links(markdown_source(cell.get("source", ""))):
+            internal_path = internal_path_from_href(link.href)
+            if internal_path is None:
+                continue
+
+            checked_links += 1
+            reason = validate_link(repo_root, tracked_files, source_path, link.href)
+            if reason is not None:
+                failures.append(
+                    LinkFailure(source_rel, f"cell {cell_index}", link.href, reason)
+                )
+
+    return checked_links, failures
+
+
+def validate_repo(repo_root, tracked_files=None):
+    repo_root = Path(repo_root).resolve()
+    if tracked_files is None:
+        tracked_files = list_tracked_files(repo_root)
+
+    failures = []
+    checked_links = 0
+    sources = source_files(tracked_files)
+
+    for source_rel in sources:
+        suffix = Path(source_rel).suffix.lower()
+        if suffix == ".ipynb":
+            file_checked_links, file_failures = validate_notebook_file(
+                repo_root,
+                tracked_files,
+                source_rel,
+            )
+        else:
+            file_checked_links, file_failures = validate_markdown_file(
+                repo_root,
+                tracked_files,
+                source_rel,
+            )
+
+        checked_links += file_checked_links
+        failures.extend(file_failures)
+
+    return ValidationReport(len(sources), checked_links, failures)
+
+
+def print_report(report, out):
+    for failure in report.failures:
+        print(
+            f'{failure.source}:{failure.location}: broken link "{failure.href}" -> '
+            f"{failure.reason}",
+            file=out,
+        )
+
+    print(
+        f"Scanned {report.scanned_files} files; checked {report.checked_links} "
+        f"internal links; {len(report.failures)} failures.",
+        file=out,
+    )
+
+
+def run(repo_root=None, tracked_files=None, out=sys.stdout):
+    if repo_root is None:
+        repo_root = Path.cwd()
+
+    try:
+        report = validate_repo(repo_root, tracked_files)
+    except subprocess.CalledProcessError as exc:
+        print(f"failed to enumerate tracked files with git ls-files: {exc}", file=out)
+        return 2
+
+    print_report(report, out)
+    return 1 if report.failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/_SUPPORT/tests/test_check_internal_links.py
+++ b/_SUPPORT/tests/test_check_internal_links.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "scripts"))
+
+import check_internal_links
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def tracked_files():
+    return check_internal_links.list_tracked_files(REPO_ROOT)
+
+
+def test_real_start_here_links_resolve():
+    tracked = tracked_files()
+    source = REPO_ROOT / "PROJECT" / "0_start_here.ipynb"
+
+    assert (
+        check_internal_links.validate_link(
+            REPO_ROOT,
+            tracked,
+            source,
+            "flow/01f_model_goal.ipynb",
+        )
+        is None
+    )
+    assert (
+        check_internal_links.validate_link(
+            REPO_ROOT,
+            tracked,
+            source,
+            "transport/01t_model_goal.ipynb",
+        )
+        is None
+    )
+
+
+def test_real_cross_tree_theory_link_resolves():
+    tracked = tracked_files()
+    source = REPO_ROOT / "PROJECT" / "flow" / "03f_modflow_fundamentals.ipynb"
+
+    assert (
+        check_internal_links.validate_link(
+            REPO_ROOT,
+            tracked,
+            source,
+            "../../THEORY/_demos/explore_porosity_and_REV.ipynb",
+        )
+        is None
+    )
+
+
+def test_readme_links_resolve():
+    tracked = tracked_files()
+    source = REPO_ROOT / "README.md"
+
+    assert (
+        check_internal_links.validate_link(REPO_ROOT, tracked, source, "DEVELOPMENT.md")
+        is None
+    )
+    assert (
+        check_internal_links.validate_link(
+            REPO_ROOT,
+            tracked,
+            source,
+            "_SUPPORT/static/figures/0_readme/Groundwater_course.jpg",
+        )
+        is None
+    )
+
+
+def test_synthetic_broken_target_fails(tmp_path):
+    (tmp_path / "doc.md").write_text("[bad](missing.ipynb)\n", encoding="utf-8")
+    output = io.StringIO()
+
+    exit_code = check_internal_links.run(
+        tmp_path,
+        tracked_files={"doc.md"},
+        out=output,
+    )
+
+    assert exit_code == 1
+    assert (
+        'doc.md:1: broken link "missing.ipynb" -> target does not exist'
+        in output.getvalue()
+    )
+
+
+def test_url_encoded_path_resolves(tmp_path):
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (tmp_path / "doc.md").write_text(
+        "[x](folder/My%20Notebook.ipynb)\n",
+        encoding="utf-8",
+    )
+    (folder / "My Notebook.ipynb").write_text("{}", encoding="utf-8")
+
+    output = io.StringIO()
+    exit_code = check_internal_links.run(
+        tmp_path,
+        tracked_files={"doc.md", "folder/My Notebook.ipynb"},
+        out=output,
+    )
+
+    assert exit_code == 0
+    assert "0 failures." in output.getvalue()
+
+
+def test_path_traversal_containment_fails(tmp_path):
+    (tmp_path / "doc.md").write_text("[bad](../../../etc/passwd)\n", encoding="utf-8")
+    output = io.StringIO()
+
+    exit_code = check_internal_links.run(
+        tmp_path,
+        tracked_files={"doc.md"},
+        out=output,
+    )
+
+    assert exit_code == 1
+    assert (
+        'doc.md:1: broken link "../../../etc/passwd" -> path escapes repo root'
+        in output.getvalue()
+    )
+
+
+def test_fenced_markdown_link_is_ignored(tmp_path):
+    (tmp_path / "doc.md").write_text(
+        "```markdown\n"
+        "[fake](inside-fence.ipynb)\n"
+        "```\n"
+        "[real](outside-fence.ipynb)\n",
+        encoding="utf-8",
+    )
+    output = io.StringIO()
+
+    exit_code = check_internal_links.run(
+        tmp_path,
+        tracked_files={"doc.md"},
+        out=output,
+    )
+
+    assert exit_code == 1
+    assert (
+        'doc.md:4: broken link "outside-fence.ipynb" -> target does not exist'
+        in output.getvalue()
+    )
+    assert "inside-fence.ipynb" not in output.getvalue()
+
+
+def test_fenced_html_link_is_ignored(tmp_path):
+    (tmp_path / "doc.md").write_text(
+        "```html\n"
+        '<a href="missing.ipynb">missing</a>\n'
+        "```\n",
+        encoding="utf-8",
+    )
+    output = io.StringIO()
+
+    exit_code = check_internal_links.run(
+        tmp_path,
+        tracked_files={"doc.md"},
+        out=output,
+    )
+
+    assert exit_code == 0
+    assert "missing.ipynb" not in output.getvalue()
+    assert "0 failures." in output.getvalue()


### PR DESCRIPTION
## Summary
Implements phase 1 and phase 1.5 of the READY plan at `DESIGN_DOCS/internal_link_validator_plan.md` — a small stdlib-only CI script that catches broken relative links inside notebooks and markdown files. The bug class this targets is the rename-induced broken-target pattern that hit during the notebook rename `95c5eed` (and required the cleanup commit `7746846`).

Phase 2 (wiring the validator into a CI workflow file) is a separate follow-up PR per the plan's phase dependency graph.

## Commits
1. **`08c635f` `feat: add internal-link validator script and tests (phase 1)`** — `_SUPPORT/src/scripts/check_internal_links.py` (validator) + `_SUPPORT/tests/test_check_internal_links.py` (8 pytest cases). Includes the code-fence-stripping follow-up that handles the FP class surfaced by the first smoke run.
2. **`62c4a66` `fix(case_study): add https:// scheme to maps.zh.ch link (phase 1.5)`** — fixes the one real broken link the validator's dry-run found. Without `https://`, the link resolved as a relative file path and 404'd for students.

## What the validator does
- Scans tracked `.ipynb` markdown cells and `.md` files under `PROJECT/`, plus root-level `.md` files (`README.md`, `DEVELOPMENT.md`, `CLAUDE.md`)
- Reports broken **internal** links only (external URLs are excluded — zero internet calls)
- Strips code-fenced regions before extraction to avoid example-link false positives
- Uses `git ls-files` for enumeration, so it skips `.venv/`, `.ipynb_checkpoints/`, and gitignored content automatically

## Test plan
- [x] \`uv run pytest _SUPPORT/tests/test_check_internal_links.py -v\` — all 8 tests pass
- [x] \`uv run python _SUPPORT/src/scripts/check_internal_links.py\` — 0 failures across 29 files / 53 internal links
- [ ] After merge: maintainer manually re-runs the validator on \`course_2026\` to confirm no new failures snuck in via concurrent merges

## Future work (not in this PR)
- **Phase 2:** add \`.github/workflows/check-internal-links.yml\` to enforce the validator on PRs. Will be a small follow-up PR.
- **Tier 1 #2:** the \`tasks_data.py\` integrity check (separate plan, not started).
- **Cherry-pick to \`main\`:** after this lands and phase 2 is in place, the validator + CI gate get propagated. Single targeted cherry-pick PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)