### PR TITLE
deps: bump jupyterlab to close alert #34 (cherry-pick of #107)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1221,6 +1221,19 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1324,26 +1337,26 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.7"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
+    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "packaging" },
-    { name = "setuptools" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Cherry-picks `1d75c21` from #107 (merged on `course_2026`) onto `main`, closing dependabot alert #34 (GHSA-vmhf-c436-hxj4, medium): JupyterLab stored XSS in extension manager via unsanitized URI protocol. Vulnerable ≤ 4.5.8, first patched 4.5.9.

- `jupyterlab 4.5.7 → 4.6.0`
- `jupyter-builder 1.0.2` added (transitive dep introduced by the bump)

Cherry-pick applied cleanly (uv.lock auto-merge, no conflicts).

## Why only the jupyterlab commit, not the full PR #107
PR #107 had two commits:
1. **`1d75c21` (jupyterlab)** — needed on both branches; this PR brings it to `main`
2. **`59b0319` (urllib3/idna catch-up)** — `course_2026`-only, since `main` already had these fixes from #98 in May 2026

Splitting them this way (per the plan in #107's body) makes the cherry-pick conflict-free; `main`'s pre-existing `urllib3 2.7.0` / `idna 3.17` are preserved untouched.

## Test plan
- [x] Cherry-pick applied cleanly via git auto-merge in \`uv.lock\`
- [x] \`uv sync\` resolves 178 packages
- [x] Final lock has \`jupyterlab 4.6.0\` + \`jupyter-builder 1.0.2\` alongside main's existing urllib3/idna
- [ ] After merge: confirm alert #34 auto-closes on the repo Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)