### PR TITLE
ci: add internal-link validator workflow (phase 2)

### DIFF
--- a/.github/workflows/check-internal-links.yml
+++ b/.github/workflows/check-internal-links.yml
@@ -1,0 +1,45 @@
+name: Check Internal Links
+
+on:
+  push:
+    paths:
+      - '**.ipynb'
+      - '**.md'
+      - 'THEORY/**'
+      - '_SUPPORT/static/**'
+      - '_SUPPORT/src/scripts/check_internal_links.py'
+      - '_SUPPORT/tests/test_check_internal_links.py'
+      - '.github/workflows/check-internal-links.yml'
+  pull_request:
+    paths:
+      - '**.ipynb'
+      - '**.md'
+      - 'THEORY/**'
+      - '_SUPPORT/static/**'
+      - '_SUPPORT/src/scripts/check_internal_links.py'
+      - '_SUPPORT/tests/test_check_internal_links.py'
+      - '.github/workflows/check-internal-links.yml'
+  workflow_dispatch:
+
+jobs:
+  check-internal-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run validator unit tests
+        run: uv run pytest _SUPPORT/tests/test_check_internal_links.py -v
+
+      - name: Run validator on repository
+        run: uv run python _SUPPORT/src/scripts/check_internal_links.py


### PR DESCRIPTION
## Summary
Implements phase 2 of `DESIGN_DOCS/internal_link_validator_plan.md` — wires the phase-1 validator script (merged via #108) into a GitHub Actions workflow so it runs as a PR gate.

Single new file: `.github/workflows/check-internal-links.yml`.

## What the workflow does
Triggers on `push` and `pull_request` (with path filters limiting it to PRs that change notebooks, markdown, link targets, the validator itself, or this workflow), plus manual `workflow_dispatch`.

Three steps after the standard Python 3.12 + uv setup:
1. `uv sync` (validator script is stdlib-only, but `pytest` needs install)
2. Run the 8 pytest cases for the validator
3. Run the validator against the repo — fails the build on any broken internal link

## Path filters
Per the READY plan (no `pyproject.toml` / `uv.lock`):
- `**.ipynb`, `**.md` — content
- `THEORY/**`, `_SUPPORT/static/**` — link targets
- The validator script + tests + this workflow file (self-trigger)

## Self-test
This PR's first CI run uses the very workflow being added. If anything's wrong with the YAML or the path filter, it'll surface on PR creation.

## Cherry-pick to \`main\` (separate follow-up)
\`main\` currently has none of the validator infrastructure (PR #108 went only to \`course_2026\`). A follow-up cherry-pick PR will bring three commits to \`main\`:
- \`08c635f\` (validator script + tests, from #108)
- \`62c4a66\` (maps.zh.ch link fix, from #108)
- \`870e3e0\` (the workflow from this PR)

Expected conflict-free; the new files don't overlap with anything currently on \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)