### PR TITLE
feat(transport): standalone flow-model bootstrap (flow_model_mf6 download)

### DIFF
--- a/config_template.py
+++ b/config_template.py
@@ -120,7 +120,7 @@ DATA_URLS = {
                 "url": "https://www.dropbox.com/scl/fi/coeml1evsu1p6o1acvb93/limmat_valley_calibrated_flow_model.zip?rlkey=45m4gmdf9lfbnlhblekwfuvg6&dl=1",
                 "filename": "limmat_valley_calibrated_flow_model.zip",
                 "layer": None,  # zip of the MF6 simulation, no GIS layer
-                # "readme_url": add after uploading the README (text provided separately)
+                "readme_url": "https://www.dropbox.com/scl/fi/lbbcvrbuce34547wji4ko/limmat_valley_calibrated_flow_model_README.md?rlkey=rhf4s3iuqy243nlelav1go7o3&dl=1",
             },
             "river_data": {
                 "url": "https://www.dropbox.com/scl/fi/q8x027ahe5cpqcbs52tei/Pegel_Tagesmittel.zip?rlkey=ewwzx25nn35ra8dfe5lui2hge&dl=1",

--- a/config_template.py
+++ b/config_template.py
@@ -112,8 +112,18 @@ DATA_URLS = {
                 "filename": "limmat_valley_calibrated_model.zip",
                 "readme_url": "https://www.dropbox.com/scl/fi/1gbut8vgrf3k0gl46bkhx/limmat_valley_calibrated_model_README.md?rlkey=yaxlxk02zwk6yf9bylw2i9pho&dl=1",
             }, 
+            "flow_model_mf6": {
+                # Transport track: the 05f-CALIBRATED MF6/DISV flow model (mean K ~361 m/d).
+                # ensure_flow_model() (model_io_utils) downloads + unzips this into
+                # <data>/limmat/calibration/ so the transport notebooks (04t/05t/08t + the
+                # student template) run standalone without first running the flow track.
+                "url": "https://www.dropbox.com/scl/fi/coeml1evsu1p6o1acvb93/limmat_valley_calibrated_flow_model.zip?rlkey=45m4gmdf9lfbnlhblekwfuvg6&dl=1",
+                "filename": "limmat_valley_calibrated_flow_model.zip",
+                "layer": None,  # zip of the MF6 simulation, no GIS layer
+                # "readme_url": add after uploading the README (text provided separately)
+            },
             "river_data": {
-                "url": "https://www.dropbox.com/scl/fi/q8x027ahe5cpqcbs52tei/Pegel_Tagesmittel.zip?rlkey=ewwzx25nn35ra8dfe5lui2hge&dl=1", 
+                "url": "https://www.dropbox.com/scl/fi/q8x027ahe5cpqcbs52tei/Pegel_Tagesmittel.zip?rlkey=ewwzx25nn35ra8dfe5lui2hge&dl=1",
                 "filename": "Pegel_Tagesmittel.zip",
                 "layer": None,  # No specific layer for river data
                 "readme_url": "https://www.dropbox.com/scl/fi/k3gsvlo1smsmum7mb3epa/readme.md?rlkey=4ahplwgp50jnhcqpckpxwqnaj&dl=1", 


### PR DESCRIPTION
Registers the 05f-calibrated MF6/DISV flow model as a downloadable asset (`flow_model_mf6`) so the transport track runs **standalone** — `ensure_flow_model()` fetches + extracts it into `~/…/limmat/calibration/` when a local calibration workspace isn't already present (e.g. from having run the flow track's `05f_calibration.ipynb`).

## Changes
- `config_template.py`: add `flow_model_mf6` entry (url + filename + readme_url) to `DATA_URLS["limmat"]["dropbox"]`.
- (`config.py` is gitignored; the same entry was added locally.)

## Verification
- Clean-room download test against the real Dropbox URL: download → extract → load `limmat_valley` (4845 cells, calibrated K mean 360.8 m/d).
- README URL reachable and serves the correct file.
- Trace confirmed flow (06f/07f/08f) and transport (04t/08t/template) both route to the calibrated model.
- Headless execution: `04t_model_implementation.ipynb` ✅ (exit 0) and `07f_sensitivity_uncertainty.ipynb` ✅ (exit 0).

Deploying to `main` so the JupyterHub sandbox (reads `main`) can be validated standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)