### PR TITLE
fix(sync): target origin/main in 0_sync_repo (sandbox is main-based)

### DIFF
--- a/0_sync_repo.ipynb
+++ b/0_sync_repo.ipynb
@@ -46,7 +46,7 @@
     "print(\"\\n\" + \"=\"*50)\n",
     "print(\"COMMITS BEHIND REMOTE:\")\n",
     "print(\"=\"*50)\n",
-    "!git log HEAD..origin/course_2026 --oneline 2>/dev/null || echo \"(up to date or branch not found)\""
+    "!git log HEAD..origin/main --oneline 2>/dev/null || echo \"(up to date or branch not found)\""
    ]
   },
   {
@@ -59,7 +59,7 @@
     "**Only run this cell if you want to discard local changes and sync with the remote.**\n",
     "\n",
     "This will:\n",
-    "- Reset all tracked files to match `origin/course_2026`\n",
+    "- Reset all tracked files to match `origin/main`\n",
     "- Remove untracked files in course directories"
    ]
   },
@@ -73,9 +73,9 @@
     "# UNCOMMENT THE LINES BELOW TO ACTUALLY RESET\n",
     "# (They're commented out to prevent accidental data loss)\n",
     "\n",
-    "# !git reset --hard origin/course_2026\n",
+    "# !git reset --hard origin/main\n",
     "# !git clean -fd\n",
-    "# print(\"\\n✓ Repository synced to origin/course_2026\")"
+    "# print(\"\\n✓ Repository synced to origin/main\")"
    ]
   },
   {


### PR DESCRIPTION
The sandbox JupyterHub is a **main-based** clone, so `git fetch origin` only updates `origin/main` and `origin/course_2026` is never created locally. Every command in `0_sync_repo.ipynb` referencing `origin/course_2026` failed with *"fatal: ambiguous argument 'origin/course_2026': unknown revision"* — meaning the sync never actually reset, and the sandbox stayed stale.

## Change
Point the sync notebook's preview (`git log HEAD..`), reset (`git reset --hard`), clean message, and Step-2 docs at `origin/main`.

## Note
Per-semester branch bumps of this file are already tracked as a follow-up; this aligns it with the current `main` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)