### PR TITLE
Add publication readiness documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use this teaching material, please cite the tagged release or repository version you used."
+title: "Applied Groundwater Modelling: From Darcy's Law to Model-Based Decisions"
+type: software
+authors:
+  - family-names: Marti
+    given-names: Beatrice
+  - name: "Applied Groundwater Modelling contributors"
+abstract: "Open teaching material for a Master-level applied groundwater modelling course using a Limmat Valley aquifer case study, MODFLOW, FloPy, and staged flow and transport notebooks."
+repository-code: "https://github.com/mabesa/applied_groundwater_modelling"
+url: "https://github.com/mabesa/applied_groundwater_modelling"
+version: "0.1.0-public-docs-draft"
+date-released: "2026-07-04"
+license: "MIT AND CC-BY-4.0"
+keywords:
+  - groundwater modelling
+  - hydrogeology education
+  - MODFLOW
+  - FloPy
+  - open educational resources
+  - Limmat Valley

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,10 @@ type: software
 authors:
   - family-names: Marti
     given-names: Beatrice
-  - name: "Applied Groundwater Modelling contributors"
+  - family-names: Kong
+    given-names: Xiang-Zhao
+  - family-names: Noël du Payrat
+    given-names: Louise
 abstract: "Open teaching material for a Master-level applied groundwater modelling course using a Limmat Valley aquifer case study, MODFLOW, FloPy, and staged flow and transport notebooks."
 repository-code: "https://github.com/mabesa/applied_groundwater_modelling"
 url: "https://github.com/mabesa/applied_groundwater_modelling"

--- a/DATA_AVAILABILITY.md
+++ b/DATA_AVAILABILITY.md
@@ -1,0 +1,73 @@
+# Data Availability
+
+This course uses public data for the Limmat Valley case study. The repository may use mirrored or preprocessed teaching copies to keep notebooks reliable during class, but those mirrors are not the authoritative data sources.
+
+Operational download metadata lives in `config_template.py`:
+
+- `url` points to the teaching download location used by the notebooks.
+- `readme_url` points to provider documentation or local processing notes where available.
+
+This file is the canonical place for provenance, terms of use, and raw-versus-derived status.
+
+Maintenance note: keep the raw-versus-derived table below in sync with the data keys in `config_template.py`. If a config key is renamed, added, or removed, update this file in the same change.
+
+## Public Data Providers
+
+| Provider | Role in course material | Terms / documentation |
+| --- | --- | --- |
+| AWEL / GIS-ZH / Canton Zurich open data | Groundwater occurrence, groundwater gauges, groundwater wells, water bodies, and related geodata | Canton Zurich open data page: https://www.zh.ch/de/politik-staat/opendata.html |
+| BAFU / FOEN | Hydrological observations such as river gauge daily values | FOEN hydrological data portal: https://www.hydrodaten.admin.ch/en/ |
+| MeteoSwiss | Climate normals used for recharge and climate-context teaching data | MeteoSwiss open data terms: https://opendatadocs.meteoswiss.ch/general/terms-of-use |
+| swisstopo | Elevation products such as DHM25 and swissALTI3D-derived terrain data | swisstopo free geodata terms: https://www.swisstopo.admin.ch/en/terms-of-use-free-geodata-and-geoservices |
+| opendata.swiss | General Swiss open-government-data terms model and dataset catalogue | https://opendata.swiss/en/terms-of-use |
+
+## Terms Summary
+
+Swiss open-government-data datasets can have dataset-specific terms. The opendata.swiss portal distinguishes several usage models, including open use with recommended attribution and open use with mandatory source citation. Check the specific dataset entry or provider documentation before redistributing data outside this course.
+
+Canton Zurich states that open data may be copied, distributed, made accessible, enriched, edited, and used commercially. For datasets under CC BY 4.0, the source must be named using the organization listed in the dataset contact plus a link to the dataset.
+
+MeteoSwiss states that its open meteorological and climatological data may be shared, processed, remixed, changed, built upon, and used commercially. MeteoSwiss requires source acknowledgement and publishes its Open Data under CC BY 4.0.
+
+swisstopo states that its free geodata and geoservices may be used, distributed, made accessible, enriched, processed, and used commercially, with mandatory source reference.
+
+BAFU/FOEN hydrological data are accessed through the public hydrological-data portal. Dataset-specific terms and attribution requirements should be checked through the provider or corresponding opendata.swiss entry before redistributing derived data.
+
+## Raw And Derived Items
+
+The table below is a working provenance map for the items referenced in `config_template.py`. "Redistribution status" is intentionally conservative where derived artifacts combine multiple public sources.
+
+| Config key / item | Status | Source provider | Derived from | Redistribution / license notes |
+| --- | --- | --- | --- | --- |
+| `climate_data` | Raw public data / mirrored teaching copy | MeteoSwiss | Not derived in this repository | MeteoSwiss Open Data are CC BY 4.0 with source acknowledgement required. |
+| `groundwater_map_norm` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
+| `dem` | Processed terrain raster | swisstopo | DHM25-derived terrain data | swisstopo attribution required. Processing should preserve provider attribution. |
+| `dem_hres` | Processed terrain raster | swisstopo | swissALTI3D-derived terrain data | swisstopo attribution required. Processing should preserve provider attribution. |
+| `gauges` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
+| `rivers` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
+| `wells` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
+| `river_data` | Raw public hydrological data / mirrored teaching copy | BAFU / FOEN | Not derived in this repository | Verify dataset-specific FOEN/opendata.swiss terms and attribution requirements. |
+| `river_cells` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata | River geodata, model grid, and modelling choices | Reuse under applicable source-provider terms plus project attribution. |
+| `model_boundary` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata and teaching choices | Aquifer/geodata interpretation and modelling scope | Reuse under applicable source-provider terms plus project attribution. |
+| `model_boundary_segments` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata and teaching choices | `model_boundary` and boundary-condition interpretation | Reuse under applicable source-provider terms plus project attribution. |
+| `chd_cells` | Derived model input / teaching artifact | Project-owned processing; based on public geodata and model grid | Model grid, boundary segments, groundwater/river context | Reuse under applicable source-provider terms plus project attribution. |
+| `wells_north` | Derived model input / teaching artifact | Project-owned processing; based on public geodata and model grid | Model grid and lateral-boundary interpretation | Reuse under applicable source-provider terms plus project attribution. |
+| `wells_south` | Derived model input / teaching artifact | Project-owned processing; based on public geodata and model grid | Model grid and lateral-boundary interpretation | Reuse under applicable source-provider terms plus project attribution. |
+| `groundwater_timeseries` | Processed observation table | AWEL / GIS-ZH / Canton Zurich | Groundwater gauge observations transformed to long format | Attribute source data provider; preserve processing notes. |
+| `parameter_zones` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata and modelling judgement | Aquifer interpretation, model grid, parameterization choices | Reuse under applicable source-provider terms plus project attribution. |
+| `baseline_model` | Derived model artifact | Project-owned model setup | Public geodata, terrain, hydrological data, and modelling assumptions | Reuse under project teaching-content terms where compatible with provider terms. Attribute public data providers. |
+| `calibrated_model` | Derived model artifact | Project-owned model setup/calibration | Baseline model, observations, calibration choices | Reuse under project teaching-content terms where compatible with provider terms. Attribute public data providers. |
+| `flow_model_mf6` | Derived model artifact | Project-owned model setup/calibration | Calibrated flow model converted/prepared for transport notebooks | Reuse under project teaching-content terms where compatible with provider terms. Attribute public data providers. |
+
+## Attribution Guidance
+
+When reusing the material, cite this repository and retain the source attribution required by the public data providers. At minimum, include attribution for:
+
+- Canton Zurich / AWEL / GIS-ZH open data where Canton Zurich geodata are used;
+- MeteoSwiss where climate normals are used;
+- Federal Office of Topography swisstopo where swisstopo elevation products are used;
+- Federal Office for the Environment FOEN/BAFU where hydrological observations are used.
+
+## Adaptation Notes
+
+The Limmat Valley workflow is place-based. It can be studied or adapted as a modelling workflow, but adaptation to a different aquifer requires replacing the data pipeline, conceptual model, boundary conditions, and validation targets.

--- a/DATA_AVAILABILITY.md
+++ b/DATA_AVAILABILITY.md
@@ -31,7 +31,7 @@ MeteoSwiss states that its open meteorological and climatological data may be sh
 
 swisstopo states that its free geodata and geoservices may be used, distributed, made accessible, enriched, processed, and used commercially, with mandatory source reference.
 
-BAFU/FOEN hydrological data are accessed through the public hydrological-data portal. Dataset-specific terms and attribution requirements should be checked through the provider or corresponding opendata.swiss entry before redistributing derived data.
+The BAFU/FOEN daily river data used in this course were provided directly by FOEN Hydrology for teaching use. The dataset contains daily discharge and water-level values for stations 2099 Limmat - Zurich, Unterhard and 2176 Sihl - Zurich, Sihlholzli for 2000-2024. Values from 2021-01-01 onward are provisional. BAFU conditions for covered hydrological raw data permit commercial and non-commercial use and recommend source attribution. Treat these data as BAFU/FOEN provider-terms data, not as project-owned CC BY material.
 
 ## Raw And Derived Items
 
@@ -46,7 +46,7 @@ The table below is a working provenance map for the items referenced in `config_
 | `gauges` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
 | `rivers` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
 | `wells` | Raw public geodata / mirrored teaching copy | AWEL / GIS-ZH / Canton Zurich | Not derived in this repository | Public OGD source. Attribute provider and dataset according to Canton Zurich terms. |
-| `river_data` | Raw public hydrological data / mirrored teaching copy | BAFU / FOEN | Not derived in this repository | Verify dataset-specific FOEN/opendata.swiss terms and attribution requirements. |
+| `river_data` | Raw public hydrological data / mirrored teaching copy | BAFU / FOEN | Not derived in this repository | Provided directly by FOEN Hydrology for teaching use; source attribution recommended. Contains daily discharge and water-level values for stations 2099 and 2176 from 2000-2024; values from 2021-01-01 onward are provisional. |
 | `river_cells` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata | River geodata, model grid, and modelling choices | Reuse under applicable source-provider terms plus project attribution. |
 | `model_boundary` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata and teaching choices | Aquifer/geodata interpretation and modelling scope | Reuse under applicable source-provider terms plus project attribution. |
 | `model_boundary_segments` | Derived geodata / teaching artifact | Project-owned processing; based on public geodata and teaching choices | `model_boundary` and boundary-condition interpretation | Reuse under applicable source-provider terms plus project attribution. |

--- a/INSTRUCTOR_GUIDE.md
+++ b/INSTRUCTOR_GUIDE.md
@@ -1,0 +1,152 @@
+# Instructor Guide
+
+This guide is for instructors, teaching assistants, and external adopters. The main [README.md](README.md) is the student entry point.
+
+## Course Identity
+
+Canonical tagline:
+
+> From Darcy's Law to Model-Based Decisions.
+
+Supporting gloss:
+
+> The course teaches students to reason like applied groundwater modellers, not just solve equations.
+
+The course is designed as a 50-50 integration of groundwater theory and applied modelling workflow. The modelling project reinforces the theory rather than replacing it.
+
+This is not a MODFLOW manual. The notebooks use MODFLOW and FloPy, but the teaching goal is the applied modelling process: defining a modelling question, making assumptions explicit, running scenarios, interpreting budgets and transport behaviour, and communicating limitations.
+
+## Target Audience
+
+The material is aimed at Master's students with basic hydrogeology background. Students typically enter with basic Darcy-law knowledge, but limited experience with full numerical modelling workflows, calibration, transport modelling, uncertainty, and professional communication.
+
+## Learning Outcomes
+
+By the end of the project, students should be able to:
+
+- formulate a groundwater modelling task from a practical question;
+- run and interpret flow and transport scenarios;
+- interpret head maps, drawdown maps, water budgets, and transport outputs;
+- estimate and communicate travel-time or arrival-time implications for a solute scenario;
+- distinguish hydrogeological signal from numerical artifacts or model instability;
+- communicate modelling choices, limitations, and uncertainty in a report and presentation.
+
+Deeper calibration, advanced debugging, and open-ended scenario development are useful extensions, but should be treated as optional unless additional supervised time is available.
+
+## Theory-To-Project Links
+
+This table is the accessible text version of the planned design figure.
+
+| Theory topic | Project connection | Expected student use |
+| --- | --- | --- |
+| Darcy law | Hydraulic gradients, flow direction, pumping response | Explain why heads and drawdown change under a scenario |
+| Boundary conditions | Model setup and scenario design | Identify which boundaries control model behaviour |
+| Water balance | Budget interpretation | Check whether model responses are physically plausible |
+| Analytical solutions and pumping tests | Plausibility checks | Compare numerical responses with simpler conceptual expectations |
+| Transport equation | Solute travel time and plume behaviour | Interpret arrival time and concentration patterns |
+| Sensitivity and uncertainty | Communication of limitations | Explain which conclusions are robust and which depend on assumptions |
+
+## Reuse Layers
+
+The material is reusable as a place-based teaching resource for the Limmat Valley aquifer. It is not packaged as a turnkey template for any aquifer.
+
+| Layer | Scope | Status | Notes |
+| --- | --- | --- | --- |
+| Layer 1 | Limmat flow scenario | Smallest teachable subset | Use this when an external course needs a compact modelling workflow without the full transport sequence. Do not describe it as a standalone reusable unit until it has been tested independently. |
+| Layer 2 | Full Limmat flow + transport course | ETH-style full implementation | Includes flow, transport, report, and presentation. Requires structured student support. |
+| Layer 3a | Shipped optional extensions | Available as enrichment | Examples include deeper calibration, sensitivity/uncertainty, and advanced scenario exploration where present in the notebooks. |
+| Layer 3b | Adaptation to another aquifer | Possible but not included | Requires replacing the data pipeline, conceptual model, boundary conditions, and validation targets. It is not a tested out-of-the-box workflow. |
+
+## Project Scope
+
+The case study includes both flow and transport because transport is a required part of the course. To keep workload bounded:
+
+- require students to understand the basic calibration concept, but make deeper calibration optional;
+- provide a calibrated flow model as a stable starting point or fallback;
+- keep required transport tasks focused on process understanding and one controlled solute-transport scenario;
+- mark extension tasks clearly as optional;
+- avoid assigning optional tasks unless supervised project time is expanded.
+
+Recommended runtime constraint: no individual model run should take more than about 10 minutes.
+
+## Support Model
+
+Do not leave students alone with the notebooks. The project can include self-study, but students need structured support.
+
+Recommended support:
+
+- explain the most important notebook sections and take-home modelling ideas in class;
+- run in-class project clinics during the project block;
+- provide a Moodle forum or equivalent shared question space;
+- aim for TA or instructor response within 24 hours during active project periods;
+- encourage peer support, while keeping expectations and deliverables clear.
+
+## Student Deliverables
+
+The canonical student deliverables are listed in [PROJECT/workspace/README.md](PROJECT/workspace/README.md). Keep the deliverables there to avoid drift between student-facing and instructor-facing documentation.
+
+Instructors or TAs should run submitted notebooks to verify that report content is reproducible from the submitted work.
+
+## Graded Versus Practice Material
+
+Exercises are intended for practice and immediate self-correction. Exercise solutions may be public because the graded work is the group-specific project interpretation, report, and presentation.
+
+Project examples and template outputs may also be public. If an instructor wants to grade a local variant using a hidden solution, they should keep that local solution outside the public repository.
+
+## Assessment
+
+The project is assessed through notebooks, report, and presentation. The assessment should reward both correct modelling work and professional communication.
+
+Report and presentation rubrics should emphasize:
+
+- clear problem statement and scenario relevance;
+- correct methods and documented assumptions;
+- readable figures and tables with units;
+- interpretation of budgets, drawdown, transport behaviour, and uncertainty;
+- concise conclusions and recommendations.
+
+## Adoption Checklist
+
+Before running the material in another course:
+
+- read the [README.md](README.md) and verify the local setup with `0_diagnostics.ipynb`;
+- check [DATA_AVAILABILITY.md](DATA_AVAILABILITY.md) and confirm that the public data terms fit your intended use;
+- review [LICENSE](LICENSE) and retain required attribution for code, teaching material, figures, and public data providers;
+- decide whether to use Layer 1, Layer 2, or optional extensions;
+- allocate supervised project clinic time;
+- decide which optional notebook sections are in scope;
+- run the required notebooks in the intended teaching environment before assigning them;
+- adapt grading weights and reporting format to your local course.
+
+## Evidence For Teaching Development
+
+For education research or a teaching-resource publication, avoid relying only on student satisfaction. Stronger evidence can include:
+
+- aggregate grades and rubric distributions;
+- quality analysis of final reports and presentations;
+- comparison with previous course years where appropriate;
+- instructor observations during project clinics;
+- short pre/post concept questions.
+
+Any student data intended for publication must be planned before collection. Complete ETH ethics, consent, and data-protection checks before collecting concept-question results, grades, student artifacts, or other student evidence for publication.
+
+Keep student feedback, consent records, grades, and identifiable student artifacts outside the public repository. Store them only in approved private locations and ensure those locations are not tracked by git.
+
+Suggested pre/post concept-question dimensions:
+
+- groundwater theory, including Darcy-law recall;
+- modelling judgement;
+- numerical-method intuition;
+- project workflow confidence.
+
+## Limitations
+
+- The case study is place-based: it uses the Limmat Valley aquifer in Zurich.
+- The workflow is not packaged for automatic transfer to another aquifer.
+- The project requires active instructor or TA support.
+- Workload is sensitive to how many optional sections are assigned.
+- The aquifer geometry is simplified for runtime and teaching constraints.
+
+## Licensing
+
+See [LICENSE](LICENSE) for the repository license structure and [DATA_AVAILABILITY.md](DATA_AVAILABILITY.md) for public data provenance and provider terms.

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,28 @@
-MIT License
+Repository License Summary
+==========================
 
-Copyright (c) 2025 Beatrice Marti
+Copyright (c) 2025-2026 Beatrice Marti and contributors
+
+This repository contains source code, teaching content, figures, notebooks, and data references. Unless a file states otherwise:
+
+- Source code, scripts, helper modules, and executable code cells are licensed under the MIT License below.
+- Teaching text, notebook prose, exercise text, markdown documentation, and project-owned figures are licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0): https://creativecommons.org/licenses/by/4.0/
+- Third-party public data remain under the terms of the original data providers. See DATA_AVAILABILITY.md.
+- Derived data and model artifacts may incorporate third-party public data and must be reused under the applicable provider terms described in DATA_AVAILABILITY.md, unless explicitly stated otherwise.
+
+For the MIT License below, "Software" means source code, scripts, helper modules, and executable code cells owned by this project. It does not include third-party data, derived data/model artifacts, teaching prose, figures, or exercise text.
+
+Notebook files are mixed-license files: executable code cells are MIT-licensed Software, while markdown/prose cells, teaching explanations, embedded exercise text, and project-owned figures are CC BY 4.0 unless a file states otherwise.
+
+MIT License
+===========
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+of the Software, to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following
+conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/PROJECT/workspace/README.md
+++ b/PROJECT/workspace/README.md
@@ -1,12 +1,15 @@
 # Student Workspace
 
-This is where you work on your project.
+You are here: `PROJECT/workspace/`. The parent course overview is in the root [README.md](../../README.md).
+
+This is where you work on your flow and transport case study.
 
 ## Getting Started
 
-1. Copy the `template/` folder to create your own workspace
-2. Rename the copy to your group name (e.g., `group_alice_bob/`)
-3. Work on your case study in your group folder
+1. Copy the `template/` folder to create your own workspace.
+2. Rename the copy to your group name, for example `group_alice_bob/`.
+3. Work only in your group folder.
+4. Keep the original `template/` folder unchanged so you can compare against it if needed.
 
 ## Template Contents
 
@@ -15,8 +18,42 @@ This is where you work on your project.
 - `case_study_flow_group_0.ipynb` - Flow model notebook template
 - `case_study_transport_group_0.ipynb` - Transport model notebook template
 
+## What You Submit
+
+Submit the complete project material via Moodle:
+
+- your completed flow notebook;
+- your completed transport notebook;
+- your flow and transport configuration files;
+- your project report covering both flow and transport;
+- your project presentation covering both flow and transport.
+
+Your TA or instructor may run your submitted notebooks to verify that the report results are reproducible.
+
+## Expected Workflow
+
+Work through the required notebook sections first. Optional sections are enrichment and should only be attempted after the required work is complete.
+
+Use the time estimates at the top of each notebook to plan your work. If a task takes much longer than the estimate, ask for help rather than spending many hours debugging alone.
+
+## Definition Of Done
+
+Before submission, check that you can answer each item below. The goal is not only to produce figures.
+
+- what modelling question your scenario addresses;
+- which parameters or boundary conditions you changed;
+- how the model response appears in heads, drawdown, budgets, and transport outputs;
+- whether the result looks like a physical signal, numerical noise, or model instability;
+- what the result implies for the practical groundwater problem.
+
+## Collaboration
+
+Work together in your assigned group. Keep track of who changed which files and coordinate before editing the same notebook.
+
+If your group uses Git for collaboration, commit and pull frequently and avoid working on the same notebook cells at the same time. Notebook merge conflicts can be difficult to resolve.
+
+For report writing, use the collaboration workflow recommended by the teaching team.
+
 ## Submission
 
-Submit via Moodle:
-- Your configuration files (`.yaml`)
-- Your completed notebooks (`.ipynb`)
+Before submitting, restart the kernel and run each notebook from top to bottom. The submitted notebooks should run without manual fixes in the course environment.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 Course materials for Master-level groundwater modeling (4 ECTS) at ETH Zurich. Combines theoretical exercises with a practical project using MODFLOW and FloPy, applied to the Limmat Valley aquifer case study.
 
+> **From Darcy's Law to Model-Based Decisions.** The course teaches students to reason like applied groundwater modellers, not just solve equations.
+
 ## 2 Quick Start for Students
 
 Choose your preferred way to work with the course materials:
@@ -148,7 +150,7 @@ The course is organized into two main phases:
 Lectures and exercises covering flow and transport fundamentals.
 
 **Materials in `THEORY/`:**
-- `exercises/` - 6 exercises reinforcing key concepts
+- `exercises/` - exercises and reminders reinforcing key concepts; most exercises are now embedded in the flow and transport notebooks
 - `_demos/` - Lecture demonstrations (e.g., porosity and REV)
 
 ### Phase 2: Project (Weeks 9-14)
@@ -172,11 +174,23 @@ The project follows a 10-step modeling methodology:
 | 5 | Calibration | `flow/05f_calibration.ipynb` | `transport/05t_calibration.ipynb` |
 | 6 | Validation | `flow/06f_validation.ipynb` | — |
 | 7 | Sensitivity & Uncertainty | `flow/07f_sensitivity_uncertainty.ipynb` | — |
-| 8 | Model Application | `flow/08f_model_application.ipynb` | — |
+| 8 | Model Application | `flow/08f_model_application.ipynb` | `transport/08t_model_application.ipynb` |
 | 9 | Documentation | `flow/09f_documentation.ipynb` | — |
 | 10 | Communication | `flow/10f_communication.ipynb` | — |
 
 The transport track builds on the calibrated flow model. Steps marked with "—" use the flow model results.
+
+### Semester Map
+
+| Period | Focus | Main student activity | Main output |
+| --- | --- | --- | --- |
+| Weeks 1-8 | Groundwater flow and transport theory | Lectures, exercises, discussions, and modelling foundations | Self-corrected exercises and exam preparation |
+| Project block | Limmat Valley case study | Flow and transport notebooks, scenario analysis, report writing, and presentation preparation | Submitted notebooks, configuration files, report, and presentation |
+| Final communication | Synthesis and communication | Present modelling results, limitations, and recommendations | Project presentation and final report |
+
+### Workload Planning
+
+The course is a 4 ECTS course. The project workload is being reassessed for HS26 using notebook time estimates, student/group time logs, project-clinic observations, and instructor/TA support tracking. Required and optional notebook sections should be planned from the time estimates shown at the top of each notebook.
 
 ### Repository Structure
 
@@ -188,7 +202,7 @@ applied_groundwater_modelling/
 ├── PROJECT/                  # Phase 2: Case study (Weeks 9-14)
 │   ├── 0_start_here.ipynb    # Course intro & 10-step framework
 │   ├── flow/                 # Flow modeling track (steps 1-10)
-│   ├── transport/            # Transport track (steps 1-5)
+│   ├── transport/            # Transport track
 │   ├── workspace/            # Your working area
 │   └── _demos/               # Calibration & uncertainty demos
 ├── _SUPPORT/                 # Helper code and static files
@@ -215,6 +229,8 @@ applied_groundwater_modelling/
 
 Course data is downloaded automatically and stored in `~/applied_groundwater_modelling_data/`.
 
+The Limmat Valley case study uses public data sources, including AWEL/GIS-ZH, BAFU, and swisstopo. The repository may use mirrors or cached teaching copies for convenient downloads, but provider portals and terms remain authoritative. See [DATA_AVAILABILITY.md](DATA_AVAILABILITY.md) for provenance, terms, and raw-versus-derived artifact notes.
+
 <details>
 <summary>Data configuration details</summary>
 
@@ -224,7 +240,7 @@ The data system uses `config.py` for data source configuration. For public data 
 cp config_template.py config.py
 ```
 
-Workshop participants receive a `config.py` with additional private datasets - don't commit this file.
+Some deployments may use a local `config.py` with alternate mirrors or temporary teaching links. Do not commit local configuration files.
 
 Data downloads automatically when needed:
 ```python
@@ -332,7 +348,20 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for:
 - Pre-commit hooks (auto-strips notebook outputs)
 - Code style and contribution guidelines
 
-## 10 Acknowledgments
+## 10 For Instructors
+
+See [INSTRUCTOR_GUIDE.md](INSTRUCTOR_GUIDE.md) for the teaching design, project scope, support model, deliverables, and reuse guidance.
+
+## 11 Citation, Licensing, And Data
+
+- See [CITATION.cff](CITATION.cff) for citation metadata.
+- See [LICENSE](LICENSE) for the repository license structure.
+- See [DATA_AVAILABILITY.md](DATA_AVAILABILITY.md) for public data provenance and provider terms.
+- See [REFERENCES.md](REFERENCES.md) for scientific and technical background references.
+
+The `course_2026` branch is a live teaching branch. For publication or formal reuse, cite a tagged release and archived DOI once available; until then, cite the repository version or commit you used.
+
+## 12 Acknowledgments
 
 Funded by the ETH Zurich Department of Earth and Planetary Sciences and the Rectors Innovendum Fund ([project link](https://innovedumprojects.ethz.ch/projects/groundwater-in-action-real-world-problem-centered-approach-with-students-collaborative-projects/)).
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,0 +1,47 @@
+# References And Further Reading
+
+This file points students and instructors to scientific and technical background for the course. It is not a required reading list. Use it as a reference map when you want more detail behind a topic.
+
+## Core Hydrogeology
+
+- Bear, J. (1979). *Hydraulics of Groundwater*. McGraw-Hill.
+- Domenico, P. A., and Schwartz, F. W. (1990). *Physical and Chemical Hydrogeology*. Wiley.
+- Freeze, R. A., and Cherry, J. A. (1979). *Groundwater*. Prentice Hall.
+
+## River-Aquifer Interaction And Boundary Conditions
+
+- Anderson, M. P., Woessner, W. W., and Hunt, R. J. (2015). *Applied Groundwater Modeling: Simulation of Flow and Advective Transport*. Academic Press.
+- Sophocleous, M. (2002). Interactions between groundwater and surface water: the state of the science. *Hydrogeology Journal*, 10, 52-67.
+- Winter, T. C. (1999). Relation of streams, lakes, and wetlands to groundwater flow systems. *Hydrogeology Journal*, 7, 28-45.
+
+## Pumping Tests And Analytical Checks
+
+- Kruseman, G. P., and de Ridder, N. A. (1991). *Analysis and Evaluation of Pumping Test Data*. International Institute for Land Reclamation and Improvement.
+
+## Numerical Groundwater Modelling
+
+- Bakker, M., Post, V., Langevin, C. D., Hughes, J. D., White, J. T., Starn, J. J., and Fienen, M. N. (2016). Scripting MODFLOW model development using Python and FloPy. *Groundwater*, 54(5), 733-739.
+- Chiang, W.-H., and Kinzelbach, W. (2001). *3-D Groundwater Modeling with PMWIN*. Springer.
+- Langevin, C. D., Hughes, J. D., Banta, E. R., Niswonger, R. G., Panday, S., and Provost, A. M. (2017). Documentation for the MODFLOW 6 groundwater flow model. U.S. Geological Survey Techniques and Methods 6-A55.
+
+## Calibration, Sensitivity, And Uncertainty
+
+- Doherty, J. (2015). *Calibration and Uncertainty Analysis for Complex Environmental Models*. Watermark Numerical Computing.
+- Hill, M. C., and Tiedeman, C. R. (2007). *Effective Groundwater Model Calibration: With Analysis of Data, Sensitivities, Predictions, and Uncertainty*. Wiley.
+
+## Solute Transport And Travel Time
+
+- Zheng, C., and Bennett, G. D. (2002). *Applied Contaminant Transport Modeling*. Wiley.
+- Zheng, C., and Wang, P. P. (1999). MT3DMS: A modular three-dimensional multispecies transport model for simulation of advection, dispersion and chemical reactions of contaminants in groundwater systems. U.S. Army Engineer Research and Development Center.
+
+## Data Providers And Terms
+
+- Canton Zurich open data: https://www.zh.ch/de/politik-staat/opendata.html
+- FOEN/BAFU hydrological data portal: https://www.hydrodaten.admin.ch/en/
+- MeteoSwiss open data terms: https://opendatadocs.meteoswiss.ch/general/terms-of-use
+- opendata.swiss terms of use: https://opendata.swiss/en/terms-of-use
+- swisstopo free geodata terms: https://www.swisstopo.admin.ch/en/terms-of-use-free-geodata-and-geoservices
+
+## Planned Reference Expansion
+
+The reading map will be expanded selectively during future literature-review work. Priority topics are: river boundary implementation, calibration workflows relevant to the course notebooks, transport travel-time interpretation, and communication of model uncertainty.

--- a/config_template.py
+++ b/config_template.py
@@ -26,7 +26,7 @@ DATA_URLS = {
                 "url": "https://www.dropbox.com/scl/fi/0tzhzcbmj64ii9faq0jp9/Grundwasservorkommen_-OGD.gpkg?rlkey=8zwfw4nv8nskmrm1h7urgsz9y&st=wz2o6bsu&dl=1",
                 "filename": "Grundwasservorkommen_-OGD.gpkg",
                 "layer": "GS_GW_LEITER_F", 
-                "readme_url": "https://www.dropbox.com/scl/fi/4w76qtxe8w3i6eztyh3p8/Produktblatt_AV_Gewasser_-OGD.pdf?rlkey=o8dt6qkrvxuqf0jagau5rz1yr&dl=1", 
+                "readme_url": "https://www.dropbox.com/scl/fi/4yaju2g94t7oq9fz8cx62/Produktblatt_Grundwasservorkommen_-OGD.pdf?rlkey=cv0952ssxt0uk0t6maldhnses&dl=1",
             }, 
             "dem": {
                 "url": "https://www.dropbox.com/scl/fi/6wq78jlj14gmmj75kzjm3/dem_converted_bbox.tif?rlkey=4tenmorf5hbyt428xkih8lt2g&dl=1",

--- a/config_template.py
+++ b/config_template.py
@@ -11,7 +11,8 @@ CASE_STUDY = "limmat"
 # "dropbox" -> Use Dropbox links
 DATA_SOURCE = "dropbox"
 
-# DATA_URLS for different case studies and sources
+# DATA_URLS for different case studies and sources.
+# Keep DATA_AVAILABILITY.md in sync when adding, removing, or renaming data keys.
 DATA_URLS = {
     "limmat": {
         "dropbox": {


### PR DESCRIPTION
## Summary
- add instructor guide, data availability statement, references, and citation metadata
- clarify repository license scope across code, teaching content, notebooks, figures, and third-party data
- update student-facing README and workspace README with semester map, workload planning, data/citation links, deliverables, and definition of done

## Validation
- checked local Markdown links
- parsed CITATION.cff as YAML
- ran git diff --check

## Notes
- no modelling notebooks were changed
- DATA_AVAILABILITY.md uses conservative wording for derived artifacts and provider terms