### PR TITLE
Setup: GIS data prefetch + branch-dynamic 0_sync_repo

### DIFF
--- a/0_diagnostics.ipynb
+++ b/0_diagnostics.ipynb
@@ -250,13 +250,42 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "## 7. Summary"
+    "## 6.5 Data Cache (one-time downloads)\n",
+    "\n",
+    "Pre-downloads the course's large GIS files (~70 MB, dominated by the 46 MB DEM and 23 MB groundwater map, plus small README sidecars) so notebook 04f doesn't pause mid-run to fetch them. Idempotent — already-present files are skipped, so re-running is cheap. Set `RUN_DATA_PREFETCH = False` below to skip (files then download on first use)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os  # ensure os is in scope for this cell\n",
+    "\n",
+    "RUN_DATA_PREFETCH = True   # set False to skip; files download on first use in the notebooks\n",
+    "if RUN_DATA_PREFETCH:\n",
+    "    from data_utils import warm_data_cache, format_cache_report\n",
+    "    cache_report = warm_data_cache(verbose=True)\n",
+    "else:\n",
+    "    cache_report = {\"items\": [], \"counts\": {}, \"total_mb\": 0, \"ok\": None}\n",
+    "    print(\"Data prefetch skipped (RUN_DATA_PREFETCH = False). Files download on first use.\")\n",
+    "diag_results['data_cache'] = cache_report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## 7. Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,6 +306,15 @@
     "for name, passed in checks:\n",
     "    status = '✓' if passed else '✗'\n",
     "    print(f\"  {status} {name}\")\n",
+    "\n",
+    "# Non-gating data cache status (network state does not affect overall_ready)\n",
+    "dc = diag_results.get('data_cache', {}); c = dc.get('counts', {})\n",
+    "if dc.get('ok') is None:\n",
+    "    print(\"  - Data cache: skipped\")\n",
+    "else:\n",
+    "    print(f\"  {'✓' if dc.get('ok') else '⚠'} Data cache: {c.get('CACHED',0)} cached, \"\n",
+    "          f\"{c.get('DOWNLOADED',0)} downloaded, {c.get('FAILED',0)} failed \"\n",
+    "          f\"({dc.get('total_mb',0):.0f} MB)\")\n",
     "\n",
     "print('=' * 40)\n",
     "if summary.get('overall_ready'):\n",

--- a/0_sync_repo.ipynb
+++ b/0_sync_repo.ipynb
@@ -37,16 +37,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Fetch latest and show status\n",
+    "# Detect the branch this environment is on, then compare it to its remote counterpart.\n",
+    "# (Works on whatever branch the hub deploys — main, course_2026, etc. — no hard-coding.)\n",
+    "import subprocess\n",
+    "branch = subprocess.run(\n",
+    "    [\"git\", \"rev-parse\", \"--abbrev-ref\", \"HEAD\"],\n",
+    "    capture_output=True, text=True).stdout.strip()\n",
+    "print(f\"Current branch: {branch}\")\n",
+    "\n",
     "!git fetch origin\n",
+    "\n",
     "print(\"\\n\" + \"=\"*50)\n",
     "print(\"LOCAL STATUS:\")\n",
     "print(\"=\"*50)\n",
     "!git status --short\n",
     "print(\"\\n\" + \"=\"*50)\n",
-    "print(\"COMMITS BEHIND REMOTE:\")\n",
+    "print(f\"COMMITS BEHIND origin/{branch}:\")\n",
     "print(\"=\"*50)\n",
-    "!git log HEAD..origin/main --oneline 2>/dev/null || echo \"(up to date or branch not found)\""
+    "!git log HEAD..origin/{branch} --oneline 2>/dev/null || echo \"(up to date, or origin/{branch} not found)\""
    ]
   },
   {
@@ -59,7 +67,7 @@
     "**Only run this cell if you want to discard local changes and sync with the remote.**\n",
     "\n",
     "This will:\n",
-    "- Reset all tracked files to match `origin/main`\n",
+    "- Reset all tracked files to match `origin/<your current branch>` (detected in Step 1)\n",
     "- Remove untracked files in course directories"
    ]
   },
@@ -72,10 +80,11 @@
    "source": [
     "# UNCOMMENT THE LINES BELOW TO ACTUALLY RESET\n",
     "# (They're commented out to prevent accidental data loss)\n",
+    "# Resets to origin/<current branch> using `branch` detected in Step 1 — run Step 1 first.\n",
     "\n",
-    "# !git reset --hard origin/main\n",
+    "# !git reset --hard origin/{branch}\n",
     "# !git clean -fd\n",
-    "# print(\"\\n✓ Repository synced to origin/main\")"
+    "# print(f\"\\n✓ Repository synced to origin/{branch}\")"
    ]
   },
   {

--- a/_SUPPORT/src/data_utils.py
+++ b/_SUPPORT/src/data_utils.py
@@ -150,6 +150,95 @@ def download_named_file(name, dest_folder=None, data_type=None):
 
     return data_path
 
+PREFETCH_GIS_FILES = [
+    "model_boundary", "model_boundary_segments",
+    "wells", "rivers",
+    "groundwater_map_norm",   # ~23 MB — 04f Section 3 (thickness)
+    "dem_hres",               # ~46 MB — 04f Section 3 (DEM/model top)
+]
+# Keep in sync with every download_named_file(..., data_type='gis') call in the notebooks.
+
+
+def format_cache_report(report) -> str:
+    """Return a plain-text table of prefetch results (one row per item) plus a summary line."""
+    lines = [
+        "Data cache prefetch — GIS files (~70 MB; actual usage slightly higher due to README sidecars)",
+        f"{'Name':<30} {'Status':<12} {'Size (MB)':>10}",
+        "-" * 56,
+    ]
+    for item in report.get("items", []):
+        name   = item.get("key", "?")
+        status = item.get("status", "?")
+        size   = item.get("size_mb")
+        size_s = f"{size:.1f}" if size is not None else "-"
+        marker = "✓" if status in ("CACHED", "DOWNLOADED") else "✗"
+        lines.append(f"  {marker}  {name:<28} {status:<12} {size_s:>10}")
+    lines.append("-" * 56)
+    c = report.get("counts", {})
+    total_mb = report.get("total_mb", 0)
+    lines.append(
+        f"  {c.get('CACHED', 0)} cached / {c.get('DOWNLOADED', 0)} downloaded / "
+        f"{c.get('FAILED', 0)} failed / {total_mb:.0f} MB total"
+    )
+    return "\n".join(lines)
+
+
+def warm_data_cache(gis_names=None, data_type="gis", data_dir=None, verbose=True) -> dict:
+    """Pre-download the common GIS files so notebooks (esp. 04f Section 3) don't pause to
+    fetch them. Idempotent: already-present files are skipped. Per-file failures are isolated
+    and reported, never raised. GIS-only (model bundles intentionally out of scope for v1)."""
+    gis_names = gis_names or PREFETCH_GIS_FILES
+    data_dir  = data_dir or get_default_data_folder()
+
+    items = []
+    for name in gis_names:
+        try:
+            info = get_data_urls().get(name)
+            if info is None:
+                items.append({
+                    "key": name, "group": "gis", "status": "FAILED",
+                    "path": None, "size_mb": None, "error": "not in DATA_URLS",
+                })
+                continue
+            dest = os.path.join(data_dir, data_type, info["filename"])
+            existed_before = os.path.exists(dest)
+            path = download_named_file(name, data_type=data_type)
+            size_mb = round(os.path.getsize(path) / 1024**2, 1)
+            status  = "CACHED" if existed_before else "DOWNLOADED"
+            items.append({
+                "key": name, "group": "gis", "status": status,
+                "path": path, "size_mb": size_mb, "error": None,
+            })
+        except Exception as e:
+            items.append({
+                "key": name, "group": "gis", "status": "FAILED",
+                "path": None, "size_mb": None, "error": str(e),
+            })
+
+    counts = {
+        "CACHED":     sum(1 for i in items if i["status"] == "CACHED"),
+        "DOWNLOADED": sum(1 for i in items if i["status"] == "DOWNLOADED"),
+        "FAILED":     sum(1 for i in items if i["status"] == "FAILED"),
+    }
+    total_mb = sum(
+        i["size_mb"] for i in items
+        if i["size_mb"] is not None and i["status"] in ("CACHED", "DOWNLOADED")
+    )
+    ok = counts["FAILED"] == 0
+
+    report = {
+        "items":    items,
+        "counts":   counts,
+        "total_mb": round(total_mb, 1),
+        "ok":       ok,
+    }
+
+    if verbose:
+        print(format_cache_report(report))
+
+    return report
+
+
 def get_data_path(data_type=None):
     """
     Get the path to data folder for the current case study.

--- a/_SUPPORT/tests/test_warm_data_cache.py
+++ b/_SUPPORT/tests/test_warm_data_cache.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for warm_data_cache and format_cache_report in data_utils.py.
+
+Tests cover:
+- Successful download (new file → DOWNLOADED)
+- Already-present file (CACHED)
+- Unknown name isolation (FAILED, does not propagate)
+- Mixed scenario: one raise, others succeed
+- Report structure and counts
+- format_cache_report output
+
+Run with: uv run pytest _SUPPORT/tests/test_warm_data_cache.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add src to path (mirrors the style in test_setup_pest_calibration.py)
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import data_utils
+from data_utils import (
+    PREFETCH_GIS_FILES,
+    format_cache_report,
+    warm_data_cache,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_fake_download(tmp_dir: Path, fake_size_bytes: int = 1024):
+    """
+    Return a monkeypatch replacement for data_utils.download_named_file.
+
+    Creates an actual file (so os.path.getsize works) and records calls.
+    """
+    calls: list[tuple] = []
+
+    def fake_download(name, dest_folder=None, data_type=None):
+        calls.append((name, dest_folder, data_type))
+        gis_subdir = tmp_dir / (data_type or "gis")
+        gis_subdir.mkdir(parents=True, exist_ok=True)
+        dest = gis_subdir / f"{name}.tif"
+        dest.write_bytes(b"x" * fake_size_bytes)
+        return str(dest)
+
+    return fake_download, calls
+
+
+def _make_fake_get_data_urls(names):
+    """Return a fake get_data_urls that includes entries for the given names."""
+    def fake_get_data_urls():
+        return {n: {"filename": f"{n}.tif", "url": f"http://fake/{n}.tif"} for n in names}
+    return fake_get_data_urls
+
+
+# =============================================================================
+# Tests: warm_data_cache report structure
+# =============================================================================
+
+class TestWarmDataCacheStructure:
+    """Report dict has the expected keys and types."""
+
+    def test_report_keys(self, monkeypatch, tmp_path):
+        names = ["layer_a", "layer_b"]
+        fake_dl, _ = _make_fake_download(tmp_path)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(names))
+
+        report = warm_data_cache(gis_names=names, data_dir=str(tmp_path), verbose=False)
+
+        assert "items" in report
+        assert "counts" in report
+        assert "total_mb" in report
+        assert "ok" in report
+
+    def test_counts_keys(self, monkeypatch, tmp_path):
+        names = ["layer_a"]
+        fake_dl, _ = _make_fake_download(tmp_path)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(names))
+
+        report = warm_data_cache(gis_names=names, data_dir=str(tmp_path), verbose=False)
+
+        for key in ("CACHED", "DOWNLOADED", "FAILED"):
+            assert key in report["counts"], f"missing key: {key}"
+
+
+# =============================================================================
+# Tests: DOWNLOADED vs CACHED classification
+# =============================================================================
+
+class TestDownloadedVsCached:
+    """First call → DOWNLOADED; second call (file already present) → CACHED."""
+
+    def test_new_file_is_downloaded(self, monkeypatch, tmp_path):
+        names = ["layer_a"]
+        fake_dl, calls = _make_fake_download(tmp_path)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(names))
+
+        report = warm_data_cache(gis_names=names, data_dir=str(tmp_path), verbose=False)
+
+        assert report["counts"]["DOWNLOADED"] == 1
+        assert report["counts"]["CACHED"] == 0
+        assert report["counts"]["FAILED"] == 0
+        assert report["ok"] is True
+
+    def test_existing_file_is_cached(self, monkeypatch, tmp_path):
+        names = ["layer_a"]
+        # Pre-create the file so existed_before=True
+        gis_dir = tmp_path / "gis"
+        gis_dir.mkdir(parents=True)
+        pre_file = gis_dir / "layer_a.tif"
+        pre_file.write_bytes(b"x" * 2048)
+
+        fake_dl, _ = _make_fake_download(tmp_path)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(names))
+
+        report = warm_data_cache(gis_names=names, data_dir=str(tmp_path), verbose=False)
+
+        assert report["counts"]["CACHED"] == 1
+        assert report["counts"]["DOWNLOADED"] == 0
+        assert report["ok"] is True
+
+
+# =============================================================================
+# Tests: failure isolation
+# =============================================================================
+
+class TestFailureIsolation:
+    """One failing item must not abort the loop; ok=False; others proceed."""
+
+    def test_unknown_name_is_failed(self, monkeypatch, tmp_path):
+        """Name not in DATA_URLS → FAILED; does not raise."""
+        good_names = ["layer_a", "layer_b"]
+        all_names = ["not_a_real_layer"] + good_names
+
+        fake_dl, _ = _make_fake_download(tmp_path)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+        # Only good names are in the URL catalog
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(good_names))
+
+        report = warm_data_cache(gis_names=all_names, data_dir=str(tmp_path), verbose=False)
+
+        assert report["counts"]["FAILED"] == 1
+        assert report["counts"]["DOWNLOADED"] == 2
+        assert report["ok"] is False
+
+        failed_items = [i for i in report["items"] if i["status"] == "FAILED"]
+        assert len(failed_items) == 1
+        assert failed_items[0]["key"] == "not_a_real_layer"
+        assert "not in DATA_URLS" in failed_items[0]["error"]
+
+    def test_raising_download_is_isolated(self, monkeypatch, tmp_path):
+        """download_named_file raising for one name must not stop others."""
+        names = ["good_layer", "bad_layer", "another_good"]
+
+        calls: list[str] = []
+
+        def fake_dl_with_raise(name, dest_folder=None, data_type=None):
+            calls.append(name)
+            if name == "bad_layer":
+                raise RuntimeError("simulated network failure")
+            gis_subdir = tmp_path / (data_type or "gis")
+            gis_subdir.mkdir(parents=True, exist_ok=True)
+            dest = gis_subdir / f"{name}.tif"
+            dest.write_bytes(b"y" * 512)
+            return str(dest)
+
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl_with_raise)
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(names))
+
+        # Must not raise
+        report = warm_data_cache(gis_names=names, data_dir=str(tmp_path), verbose=False)
+
+        assert report["counts"]["FAILED"] == 1
+        assert report["counts"]["DOWNLOADED"] == 2
+        assert report["ok"] is False
+        assert set(calls) == set(names), "loop must have called download for all names"
+
+        failed = [i for i in report["items"] if i["status"] == "FAILED"]
+        assert failed[0]["key"] == "bad_layer"
+        assert "simulated network failure" in failed[0]["error"]
+
+    def test_all_failed_is_not_ok(self, monkeypatch, tmp_path):
+        """When every item fails, ok must be False."""
+        names = ["x", "y"]
+        monkeypatch.setattr(data_utils, "get_data_urls", lambda: {})  # empty catalog
+
+        fake_dl, _ = _make_fake_download(tmp_path)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+
+        report = warm_data_cache(gis_names=names, data_dir=str(tmp_path), verbose=False)
+
+        assert report["ok"] is False
+        assert report["counts"]["FAILED"] == 2
+
+
+# =============================================================================
+# Tests: total_mb accounting
+# =============================================================================
+
+class TestTotalMb:
+    """total_mb is the sum of sizes for CACHED + DOWNLOADED items only."""
+
+    def test_total_mb_excludes_failed(self, monkeypatch, tmp_path):
+        good_names = ["layer_a"]
+        all_names = ["not_a_real_layer"] + good_names
+
+        # 1 MB files
+        fake_dl, _ = _make_fake_download(tmp_path, fake_size_bytes=1024 * 1024)
+        monkeypatch.setattr(data_utils, "download_named_file", fake_dl)
+        monkeypatch.setattr(data_utils, "get_data_urls", _make_fake_get_data_urls(good_names))
+
+        report = warm_data_cache(gis_names=all_names, data_dir=str(tmp_path), verbose=False)
+
+        # Failed item has no size; total_mb should only count the good one
+        assert report["total_mb"] > 0
+        # Verify the failed item has None size
+        failed = [i for i in report["items"] if i["status"] == "FAILED"]
+        assert failed[0]["size_mb"] is None
+
+
+# =============================================================================
+# Tests: format_cache_report
+# =============================================================================
+
+class TestFormatCacheReport:
+    """format_cache_report produces a non-empty, human-readable string."""
+
+    def _make_report(self, items):
+        counts = {
+            "CACHED":     sum(1 for i in items if i["status"] == "CACHED"),
+            "DOWNLOADED": sum(1 for i in items if i["status"] == "DOWNLOADED"),
+            "FAILED":     sum(1 for i in items if i["status"] == "FAILED"),
+        }
+        total_mb = sum(
+            i["size_mb"] for i in items
+            if i["size_mb"] is not None and i["status"] in ("CACHED", "DOWNLOADED")
+        )
+        return {
+            "items": items,
+            "counts": counts,
+            "total_mb": round(total_mb, 1),
+            "ok": counts["FAILED"] == 0,
+        }
+
+    def test_returns_string(self):
+        report = self._make_report([
+            {"key": "layer_a", "group": "gis", "status": "CACHED",
+             "path": "/tmp/layer_a.tif", "size_mb": 5.0, "error": None},
+        ])
+        text = format_cache_report(report)
+        assert isinstance(text, str)
+        assert len(text) > 0
+
+    def test_contains_all_names(self):
+        items = [
+            {"key": "layer_a", "group": "gis", "status": "DOWNLOADED",
+             "path": "/tmp/layer_a.tif", "size_mb": 10.0, "error": None},
+            {"key": "bad_layer", "group": "gis", "status": "FAILED",
+             "path": None, "size_mb": None, "error": "simulated"},
+        ]
+        text = format_cache_report(self._make_report(items))
+        assert "layer_a" in text
+        assert "bad_layer" in text
+
+    def test_summary_line_present(self):
+        items = [
+            {"key": "layer_a", "group": "gis", "status": "CACHED",
+             "path": "/tmp/layer_a.tif", "size_mb": 3.5, "error": None},
+            {"key": "layer_b", "group": "gis", "status": "DOWNLOADED",
+             "path": "/tmp/layer_b.tif", "size_mb": 7.2, "error": None},
+        ]
+        text = format_cache_report(self._make_report(items))
+        # Summary line should mention cached / downloaded / failed
+        assert "cached" in text.lower()
+        assert "downloaded" in text.lower()
+        assert "failed" in text.lower()
+
+    def test_checkmarks_and_crosses(self):
+        items = [
+            {"key": "ok_layer", "group": "gis", "status": "CACHED",
+             "path": "/tmp/ok.tif", "size_mb": 1.0, "error": None},
+            {"key": "bad_layer", "group": "gis", "status": "FAILED",
+             "path": None, "size_mb": None, "error": "oops"},
+        ]
+        text = format_cache_report(self._make_report(items))
+        assert "✓" in text
+        assert "✗" in text
+
+
+# =============================================================================
+# Tests: PREFETCH_GIS_FILES constant
+# =============================================================================
+
+class TestPrefetchGisFilesConstant:
+    """PREFETCH_GIS_FILES contains the six required names."""
+
+    def test_required_names_present(self):
+        required = {
+            "model_boundary",
+            "model_boundary_segments",
+            "wells",
+            "rivers",
+            "groundwater_map_norm",
+            "dem_hres",
+        }
+        assert required.issubset(set(PREFETCH_GIS_FILES)), (
+            f"Missing from PREFETCH_GIS_FILES: {required - set(PREFETCH_GIS_FILES)}"
+        )
+
+    def test_is_list(self):
+        assert isinstance(PREFETCH_GIS_FILES, list)
+        assert len(PREFETCH_GIS_FILES) >= 6


### PR DESCRIPTION
Two hub-setup improvements (verified, GIS-only scope, no overlap with the recent docs work):

## 1. GIS data prefetch in `0_diagnostics.ipynb` (829f78f)
Adds `warm_data_cache()` / `format_cache_report()` to `data_utils.py` and a "6.5 Data Cache" step that pre-downloads the six common GIS files (`dem_hres` 46 MB + `groundwater_map_norm` 23 MB dominate) so `04f` Section 3 no longer pauses ~70 MB mid-run. Idempotent, per-file failure isolation, non-gating summary line. +14 unit tests.

## 2. Branch-dynamic `0_sync_repo.ipynb` (44bcd7d)
Sync now targets `origin/<current branch>` instead of hard-coded `main`, so it works whatever the hub deploys (main / course_2026 / future course_2027) with no per-semester edit, plus a graceful "not found" guard.

## Verification
- `warm_data_cache`: 14/14 unit tests; full-notebook headless run of `0_diagnostics` exits 0 (cold→downloads, warm→all CACHED, 75 MB, failure-isolated, opt-out works).
- `0_sync_repo`: headless run exits 0, branch detected, "not found" guard fires correctly.
- No overlap with the #121 docs work.

Targets `course_2026` only; `course_2026`→`main` will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)