### PR TITLE
Equalize learning across transport student groups (G4/G8 retune + flip-verdict node)

### DIFF
--- a/PROJECT/workspace/template/case_config_transport.yaml
+++ b/PROJECT/workspace/template/case_config_transport.yaml
@@ -422,8 +422,8 @@ transport_scenarios:
           # relative to the extraction well. ~93 m upgradient, lateral 76 m vs capture
           # y_max=Q/(2Ti)~99 m (Q=1370 m3/d, T~3000 m2/d, i~0.0023) -> inside capture geometry,
           # but Cr-VI is strongly retarded (R~19): the retarded front cannot cover the
-          # distance within the time budget.
-          # Tested outcome: does NOT reach the well (retardation-limited, R~19).
+          # distance over a short time budget. The exercise window is extended so
+          # students can interpret the delayed, retarded breakthrough.
           easting: 53.0              # m, +E offset from extraction well (upgradient)
           northing: -76.0            # m, -N offset from extraction well (upgradient)
           layer: 1
@@ -431,15 +431,21 @@ transport_scenarios:
         # TODO: Adjust duration of source activation based on model runs to
         # ensure plume reaches monitoring point. Minimum 1 day.
         duration_days: 1               # 1-day spill
-        concentration_mg_L: 20.0
+        # Source concentration set to 13 mg/L so the delayed retarded front stays
+        # clearly (not marginally) below the 0.1 mg/L threshold. Transport is linear
+        # in source concentration (linear sorption, no decay), so peak ~ 0.079 mg/L
+        # (~21% below threshold). The lesson is the RETARDATION-delayed arrival, not
+        # a knife-edge threshold call. A 13 mg/L dissolved Cr-VI plume from a
+        # plating spill is realistic/conservative.
+        concentration_mg_L: 13.0
         ssm_itype: -1
 
       simulation:
         # TODO: Adjust simulation duration based on model runs to ensure plume
         # reaches monitoring point. Minimum 30 days.
-        duration_days: 30
+        duration_days: 730
         # TODO: Adjust output times to capture key transport dynamics
-        output_times_days: [5, 15, 21, 31]
+        output_times_days: [90, 180, 365, 548, 730]
 
       submodel:
         # TODO: Adjust buffer size based on estimated plume travel distance
@@ -726,12 +732,22 @@ transport_scenarios:
         release_type: "pulse"
         location:
           # VALIDATED spill placement (scenario testing), as an easting/northing OFFSET
-          # relative to the extraction well. ~278 m upgradient, lateral 233 m within the LARGE
+          # relative to the extraction well. Scenario-realism retune: place the allotment
+          # about 100 m from the well so the single pulse can arrive within the fixed 60 d
+          # window while preserving the same Q, reactions, and grid settings.
+          # Previous validated offset was ~278 m upgradient, lateral 233 m within the LARGE
           # capture y_max=Q/(2Ti)~417 m (Q=5760 m3/d, T~3000 m2/d, i~0.0023), but atrazine is
           # sorbing (Kd~0.3) and the source is a single 1-day pulse.
-          # Tested outcome: does NOT reach the well (retardation + short pulse).
-          easting: -151.0            # m, -E offset from extraction well (upgradient)
-          northing: -233.0           # m, -N offset from extraction well (upgradient)
+          # An intermediate ~150 m offset was also tested and rejected: it produced a peak
+          # of ~4e-4 mg/L at the well, numerically indistinguishable from zero and
+          # uninterpretable as a teaching case. The ~98 m placement (offset easting -53,
+          # northing -82) yields a resolvable, sub-threshold breakthrough that clearly
+          # demonstrates sorption-retarded transport. This is a deliberate scenario-realism
+          # trade: a garden allotment ~98 m from the extraction well is physically credible
+          # (the site also sits ~60 m from other, non-modelled Bullingerstrasse abstraction
+          # wells) and produces a pedagogically clear result.
+          easting: -53.0             # m, -E offset from extraction well (upgradient)
+          northing: -82.0            # m, -N offset from extraction well (upgradient)
           layer: 1
         start_time_days: 0
         # TODO: Adjust duration of source activation based on model runs to
@@ -757,5 +773,4 @@ transport_scenarios:
       monitoring:
         threshold_mg_L: 0.1             # Drinking water standard (EU)
         compliance_location: "Groundwater monitoring network"
-
 

--- a/PROJECT/workspace/template/case_study_transport_group_0.ipynb
+++ b/PROJECT/workspace/template/case_study_transport_group_0.ipynb
@@ -295,6 +295,20 @@
    "id": "9",
    "metadata": {},
    "source": [
+    "## One-change flip test\n",
+    "\n",
+    "Choose **one** physically defensible scenario knob that could flip your verdict: source location, source concentration, release duration, simulation horizon, or **pumping rate**. Do **not** change the locked physics (α_L, α_T, n_e, diffusion, TVD, or grid refinement) and do **not** change the instructor-pinned reactions (R / Kd or decay).\n",
+    "\n",
+    "Before you rerun, predict the direction and mechanism: for example, moving the source into the capture zone, increasing concentration or release duration, extending the horizon for a retarded plume, or changing pumping rate. For a no-reach case, a valid real lever is to **increase the pumping rate to widen the capture zone until it intercepts the plume**.\n",
+    "\n",
+    "Report original vs modified peak concentration, time of peak, and verdict.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
     "## §5 — Interpret and answer the scenario question\n",
     "\n",
     "Use the verdict above to answer, in your report:\n",
@@ -323,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## §6 — Deliverable checklist\n",
@@ -342,7 +356,12 @@
     "      decay / dilution).\n",
     "- [ ] **Defensible-threshold judgment** (§5) — state which claims your model supports\n",
     "      (longitudinal / receptor) and which it does **not** (lateral contaminated area).\n",
+    "- [ ] **Flip-verdict test** — one physically defensible change, your predicted\n",
+    "      direction + mechanism before rerun, and original vs modified peak / time /\n",
+    "      verdict.\n",
     "- [ ] **Model files** — the cached scenario in your group workspace.\n",
+    "\n",
+    "Below-threshold and no-reach outcomes are graded on judgment quality and mechanism evidence (capture-zone half-width, retardation delay, dilution), not on having a high peak.\n",
     "\n",
     "**Rubric mapping.** This phase feeds **Conceptual Model (15%)** — the assumptions you\n",
     "state and defend — and **Results & Interpretation (20%)** — the breakthrough result\n",


### PR DESCRIPTION
Fixes the learning-equity gap where 3 "no-reach" groups produced near-zero peaks (nothing to interpret). **Hybrid**: keep ONE genuine no-reach (G1, capture-zone bypass — the richest no-reach lesson), give G4 and G8 interpretable sub-threshold breakthroughs.

## Changes (2 files)
- **G4 (Cr-VI):** window 30→730 d so the retarded (R≈19) front arrives; source 20→13 mg/L for a stable ~21%-below-threshold margin (peak ≈0.079/0.1) — teaches **retardation-delayed arrival**.
- **G8 (Atrazine):** source ~278→~98 m (same direction, 60 d window; decay/Kd/Q/grid unchanged) so the pulse arrives (peak ≈0.018/0.1, dilution). Realism rationale documented in-config.
- **G1 unchanged** — the retained genuine no-reach (capture-zone "is the well protected?" judgment).
- **Template:** "One-change flip test" node (excludes locked physics + pinned reactions; no-reach lever = raise Q to widen capture) + §6 flip-verdict checklist + parity note (below/no-reach graded on judgment, not peak).

New spread: **4 above (G2/5/6/7) / 4 below-arriving (G0/G3/G4/G8) / 1 no-reach (G1).**

## Process
Planned → adversarially reviewed → deliberated → implemented → independently verified → verifier findings applied (G4 margin, G8 rationale). Locked physics + instructor-pinned reactions untouched; G4/G8 re-validated locally (Cr 0.90, Pe_L≤2, <600 s).

**Gate:** authoritative 9-group Linux hub validation (`validate_transport_groups.py`) still to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)