### PR TITLE
Split build_refined_gwf_model into generate_refined_grid + assemble_gwf_from_spec

### DIFF
--- a/_SUPPORT/src/model_io_utils.py
+++ b/_SUPPORT/src/model_io_utils.py
@@ -1991,10 +1991,13 @@ def generate_refined_grid(
     Returns
     -------
     dict
-        Spec consumed by :func:`assemble_gwf_from_spec`: ``gridprops``,
-        ``ncpl``, ``modelgrid``, ``top``, ``botm``, ``k``, ``strt``,
-        ``recharge``, ``chd_spd``, ``riv_spd``, ``wel_spd``, ``well_cells``,
-        ``crs``, and (optionally) ``baseline_heads``.
+        Plain-array spec consumed by :func:`assemble_gwf_from_spec` — no
+        live MF6 objects, no VertexGrid: ``gridprops``, ``ncpl``, ``top``,
+        ``botm``, ``k``, ``rch``, ``strt``, ``idomain``, ``chd_cellid``,
+        ``chd_head``, ``riv_cellid``, ``riv_stage``, ``riv_cond``,
+        ``riv_rbot``, ``wel_cellid``, ``wel_rate``, ``well_cells``,
+        ``refine_radius_used``, ``crs``, and (optionally)
+        ``baseline_heads``.
     """
     from scipy.interpolate import NearestNDInterpolator
     from shapely.geometry import Point as ShapelyPoint
@@ -2105,6 +2108,8 @@ def generate_refined_grid(
         if rec[0] not in seen:
             seen.add(rec[0])
             chd_dedup.append(rec)
+    chd_cellid = [rec[0] for rec in chd_dedup]
+    chd_head = [rec[1] for rec in chd_dedup]
     print(f"CHD cells: {len(chd_dedup)}")
 
     # ------------------------------------------------------------------
@@ -2118,7 +2123,7 @@ def generate_refined_grid(
     ])
     stage_nn = NearestNDInterpolator(riv_xy, [r['stage'] for r in riv_orig])
     rbot_nn = NearestNDInterpolator(riv_xy, [r['rbot'] for r in riv_orig])
-    riv_cond = np.array([r['cond'] for r in riv_orig])
+    riv_cond_orig = np.array([r['cond'] for r in riv_orig])
 
     orig_riv_areas = np.array([
         ShapelyPolygon(coarse_modelgrid.get_cell_vertices(
@@ -2132,46 +2137,55 @@ def generate_refined_grid(
     ].geometry.union_all()
     river_prep = shapely_prep(river_union)
 
-    riv_spd = []
+    riv_cellid = []
+    riv_stage = []
+    riv_cond = []
+    riv_rbot = []
     for i in range(ncpl):
         if river_prep.contains(ShapelyPoint(xc_ref[i], yc_ref[i])):
             dists = (riv_xy[:, 0] - xc_ref[i])**2 + (riv_xy[:, 1] - yc_ref[i])**2
             j = np.argmin(dists)
             area_new = ShapelyPolygon(mg_ref.get_cell_vertices(i)).area
-            cond_scaled = riv_cond[j] * area_new / orig_riv_areas[j]
-            riv_spd.append((
-                (0, i),
-                float(stage_nn(xc_ref[i], yc_ref[i])),
-                float(cond_scaled),
-                float(rbot_nn(xc_ref[i], yc_ref[i])),
-            ))
-    print(f"RIV cells: {len(riv_spd)}")
+            cond_scaled = riv_cond_orig[j] * area_new / orig_riv_areas[j]
+            riv_cellid.append((0, i))
+            riv_stage.append(float(stage_nn(xc_ref[i], yc_ref[i])))
+            riv_cond.append(float(cond_scaled))
+            riv_rbot.append(float(rbot_nn(xc_ref[i], yc_ref[i])))
+    print(f"RIV cells: {len(riv_cellid)}")
 
     # ------------------------------------------------------------------
     # 6. WEL
     # ------------------------------------------------------------------
     well_cells_out = []
-    wel_spd = []
+    wel_cellid = []
+    wel_rate = []
     if well_data:
         for wx, wy, rate in well_data:
             wc = int(np.argmin((xc_ref - wx)**2 + (yc_ref - wy)**2))
-            wel_spd.append(((0, wc), rate))
+            wel_cellid.append((0, wc))
+            wel_rate.append(rate)
             well_cells_out.append(wc)
-        print(f"WEL cells: {len(wel_spd)}")
+        print(f"WEL cells: {len(wel_cellid)}")
 
     spec: Dict[str, Any] = {
         'gridprops': gridprops,
         'ncpl': ncpl,
-        'modelgrid': mg_ref,
         'top': top_ref,
         'botm': botm_ref,
         'k': k_ref,
+        'rch': rch_ref,
         'strt': strt_ref,
-        'recharge': rch_ref,
-        'chd_spd': chd_dedup,
-        'riv_spd': riv_spd,
-        'wel_spd': wel_spd,
+        'idomain': np.ones(ncpl, dtype=int),
+        'chd_cellid': chd_cellid,
+        'chd_head': chd_head,
+        'riv_cellid': riv_cellid,
+        'riv_stage': riv_stage,
+        'riv_cond': riv_cond,
+        'riv_rbot': riv_rbot,
+        'wel_cellid': wel_cellid,
+        'wel_rate': wel_rate,
         'well_cells': well_cells_out,
+        'refine_radius_used': refine_radius,
         'crs': str(boundary_gdf.crs),
     }
     if bl_heads_ref is not None:
@@ -2187,8 +2201,12 @@ def assemble_gwf_from_spec(
     """
     Build, write, and run an MF6 GWF simulation from a frozen grid spec.
 
-    Pure MF6 construction — no interpolation or spatial reasoning happens
-    here.  *spec* is the dict produced by :func:`generate_refined_grid`.
+    Pure MF6 construction — no Triangle/Voronoi grid generation, no
+    NearestND interpolation, no spatial (point-in-polygon / nearest)
+    reassignment happens here.  *spec* is the frozen plain-array dict
+    produced by :func:`generate_refined_grid`; every required key is
+    accessed directly (no defaulting) so a spec missing a key fails with
+    a ``KeyError`` before anything is built.
 
     Parameters
     ----------
@@ -2240,7 +2258,7 @@ def assemble_gwf_from_spec(
     )
     _flopy.mf6.ModflowGwfdisv(
         ref_gwf, nlay=1, ncpl=ncpl, nvert=gridprops['nvert'],
-        top=spec['top'], botm=[spec['botm']],
+        top=spec['top'], botm=[spec['botm']], idomain=[spec['idomain']],
         vertices=gridprops['vertices'], cell2d=gridprops['cell2d'],
     )
     _flopy.mf6.ModflowGwfnpf(
@@ -2248,15 +2266,23 @@ def assemble_gwf_from_spec(
         save_specific_discharge=True, save_saturation=True,
     )
     _flopy.mf6.ModflowGwfic(ref_gwf, strt=spec['strt'])
-    _flopy.mf6.ModflowGwfrcha(ref_gwf, recharge=spec['recharge'])
+    _flopy.mf6.ModflowGwfrcha(ref_gwf, recharge=spec['rch'])
 
     # ------------------------------------------------------------------
-    # 2. CHD / RIV / WEL packages
+    # 2. CHD / RIV / WEL packages — built from frozen cellid/value arrays
     # ------------------------------------------------------------------
-    _flopy.mf6.ModflowGwfchd(ref_gwf, stress_period_data=spec['chd_spd'])
-    _flopy.mf6.ModflowGwfriv(ref_gwf, stress_period_data=spec['riv_spd'])
-    if spec['wel_spd']:
-        _flopy.mf6.ModflowGwfwel(ref_gwf, stress_period_data=spec['wel_spd'])
+    chd_spd = list(zip(spec['chd_cellid'], spec['chd_head']))
+    _flopy.mf6.ModflowGwfchd(ref_gwf, stress_period_data=chd_spd)
+
+    riv_spd = list(zip(
+        spec['riv_cellid'], spec['riv_stage'], spec['riv_cond'], spec['riv_rbot'],
+    ))
+    _flopy.mf6.ModflowGwfriv(ref_gwf, stress_period_data=riv_spd)
+
+    wel_cellid = spec['wel_cellid']
+    if wel_cellid:
+        wel_spd = list(zip(wel_cellid, spec['wel_rate']))
+        _flopy.mf6.ModflowGwfwel(ref_gwf, stress_period_data=wel_spd)
 
     # ------------------------------------------------------------------
     # 3. OC, write, run
@@ -2278,7 +2304,9 @@ def assemble_gwf_from_spec(
         )
 
     heads = ref_gwf.output.head().get_data().flatten()
-    ref_gwf.modelgrid.set_coord_info(crs=spec['crs'])
+    crs = spec.get('crs')
+    if crs is not None:
+        ref_gwf.modelgrid.set_coord_info(crs=crs)
     print(f"Refined model completed. Head range: "
           f"{heads.min():.2f} – {heads.max():.2f} m")
 
@@ -2368,10 +2396,10 @@ def build_refined_gwf_model(
     """
     import shutil
 
-    workspace = Path(workspace)
-    if workspace.exists():
-        shutil.rmtree(workspace)
-    workspace.mkdir(parents=True)
+    workspace_path = Path(workspace)
+    if workspace_path.exists():
+        shutil.rmtree(workspace_path)
+    workspace_path.mkdir(parents=True)
 
     spec = generate_refined_grid(
         gwf=gwf,

--- a/_SUPPORT/src/model_io_utils.py
+++ b/_SUPPORT/src/model_io_utils.py
@@ -1938,27 +1938,27 @@ def build_prt_model(
     }
 
 
-def build_refined_gwf_model(
+def generate_refined_grid(
     gwf,
     boundary_gdf: gpd.GeoDataFrame,
     river_gdf: gpd.GeoDataFrame,
     refine_points: Union[List[tuple], gpd.GeoDataFrame],
     head_array: np.ndarray,
-    workspace: Union[str, Path],
     refine_radius: float = 200.0,
     base_cell_size: float = 50.0,
     refined_cell_size: float = 10.0,
     well_data: Optional[List[tuple]] = None,
-    sim_name: str = "refined_model",
     baseline_head_array: Optional[np.ndarray] = None,
 ) -> Dict[str, Any]:
     """
-    Build and run a locally-refined GWF model from an existing coarse model.
+    Build a locally-refined Voronoi grid and interpolate/reassign all
+    model inputs from an existing coarse GWF model onto it.
 
-    Creates a new Voronoi grid with refinement zones around each point in
-    *refine_points*, interpolates all properties from the coarse model via
-    nearest-neighbour, transfers CHD / RIV / WEL boundary conditions, and
-    runs the simulation.
+    This performs every step that depends on geometry — grid generation,
+    nearest-neighbour interpolation of arrays, and spatial reassignment of
+    CHD / RIV / WEL boundary conditions — and returns a frozen "spec" dict
+    of plain arrays/lists with no MF6 objects. :func:`assemble_gwf_from_spec`
+    turns that spec into an actual simulation.
 
     Parameters
     ----------
@@ -1975,8 +1975,6 @@ def build_refined_gwf_model(
     head_array : numpy.ndarray
         Head array from the coarse model (used as starting heads on the
         refined grid).  Shape must match the coarse DISV grid.
-    workspace : str or Path
-        Directory for the refined simulation files.
     refine_radius : float, optional
         Radius of refinement circle around each point (m).  Default 200.
     base_cell_size : float, optional
@@ -1985,8 +1983,6 @@ def build_refined_gwf_model(
         Cell size inside refinement zones (m).  Default 10.
     well_data : list of (x, y, rate) tuples, optional
         Well locations and rates to add via WEL package.
-    sim_name : str, optional
-        MF6 simulation / model name.
     baseline_head_array : numpy.ndarray, optional
         Head array from the *coarse* baseline model (before scenario
         changes).  When provided, it is interpolated onto the refined grid
@@ -1995,28 +1991,16 @@ def build_refined_gwf_model(
     Returns
     -------
     dict
-        ``sim``            – MFSimulation
-        ``gwf``            – ModflowGwf (refined)
-        ``modelgrid``      – refined VertexGrid
-        ``gridprops``      – DISV grid properties dict
-        ``ncpl``           – cells per layer
-        ``heads``          – 1-D head array from the run
-        ``well_cells``     – list of flat cell indices (one per well_data entry)
-        ``baseline_heads`` – 1-D head array on refined grid (only when
-                             *baseline_head_array* is given)
+        Spec consumed by :func:`assemble_gwf_from_spec`: ``gridprops``,
+        ``ncpl``, ``modelgrid``, ``top``, ``botm``, ``k``, ``strt``,
+        ``recharge``, ``chd_spd``, ``riv_spd``, ``wel_spd``, ``well_cells``,
+        ``crs``, and (optionally) ``baseline_heads``.
     """
-    import shutil
     from scipy.interpolate import NearestNDInterpolator
     from shapely.geometry import Point as ShapelyPoint
     from shapely.geometry import Polygon as ShapelyPolygon
     from shapely.prepared import prep as shapely_prep
     import disv_grid_utils as dgu
-    import flopy as _flopy
-
-    workspace = Path(workspace)
-    if workspace.exists():
-        shutil.rmtree(workspace)
-    workspace.mkdir(parents=True)
 
     # ------------------------------------------------------------------
     # 1. Normalise refine_points → list of (x, y)
@@ -2094,38 +2078,7 @@ def build_refined_gwf_model(
     )(xc_ref, yc_ref)
 
     # ------------------------------------------------------------------
-    # 4. Build GWF simulation
-    # ------------------------------------------------------------------
-    ref_sim = _flopy.mf6.MFSimulation(
-        sim_name=sim_name, exe_name='mf6', sim_ws=str(workspace),
-    )
-    _flopy.mf6.ModflowTdis(
-        ref_sim, time_units='DAYS', nper=1, perioddata=[(1.0, 1, 1)],
-    )
-    # Keep the refined solver aligned with the course NEWTON policy.
-    _flopy.mf6.ModflowIms(
-        ref_sim,
-        **GWF_NEWTON_IMS_OPTIONS,
-    )
-
-    ref_gwf = _flopy.mf6.ModflowGwf(
-        ref_sim, modelname=sim_name, save_flows=True,
-        newtonoptions=GWF_NEWTON_OPTIONS,
-    )
-    _flopy.mf6.ModflowGwfdisv(
-        ref_gwf, nlay=1, ncpl=ncpl, nvert=gridprops['nvert'],
-        top=top_ref, botm=[botm_ref],
-        vertices=gridprops['vertices'], cell2d=gridprops['cell2d'],
-    )
-    _flopy.mf6.ModflowGwfnpf(
-        ref_gwf, icelltype=1, k=k_ref, save_flows=True,
-        save_specific_discharge=True, save_saturation=True,
-    )
-    _flopy.mf6.ModflowGwfic(ref_gwf, strt=strt_ref)
-    _flopy.mf6.ModflowGwfrcha(ref_gwf, recharge=rch_ref)
-
-    # ------------------------------------------------------------------
-    # 5. CHD transfer
+    # 4. CHD transfer
     # ------------------------------------------------------------------
     chd_orig = gwf.get_package('CHD')
     chd_data = chd_orig.stress_period_data.get_data(0)
@@ -2152,11 +2105,10 @@ def build_refined_gwf_model(
         if rec[0] not in seen:
             seen.add(rec[0])
             chd_dedup.append(rec)
-    _flopy.mf6.ModflowGwfchd(ref_gwf, stress_period_data=chd_dedup)
     print(f"CHD cells: {len(chd_dedup)}")
 
     # ------------------------------------------------------------------
-    # 6. RIV transfer
+    # 5. RIV transfer
     # ------------------------------------------------------------------
     riv_orig = gwf.get_package('RIV').stress_period_data.get_data(0)
     riv_xy = np.array([
@@ -2193,24 +2145,121 @@ def build_refined_gwf_model(
                 float(cond_scaled),
                 float(rbot_nn(xc_ref[i], yc_ref[i])),
             ))
-    _flopy.mf6.ModflowGwfriv(ref_gwf, stress_period_data=riv_spd)
     print(f"RIV cells: {len(riv_spd)}")
 
     # ------------------------------------------------------------------
-    # 7. WEL
+    # 6. WEL
     # ------------------------------------------------------------------
     well_cells_out = []
+    wel_spd = []
     if well_data:
-        wel_spd = []
         for wx, wy, rate in well_data:
             wc = int(np.argmin((xc_ref - wx)**2 + (yc_ref - wy)**2))
             wel_spd.append(((0, wc), rate))
             well_cells_out.append(wc)
-        _flopy.mf6.ModflowGwfwel(ref_gwf, stress_period_data=wel_spd)
         print(f"WEL cells: {len(wel_spd)}")
 
+    spec: Dict[str, Any] = {
+        'gridprops': gridprops,
+        'ncpl': ncpl,
+        'modelgrid': mg_ref,
+        'top': top_ref,
+        'botm': botm_ref,
+        'k': k_ref,
+        'strt': strt_ref,
+        'recharge': rch_ref,
+        'chd_spd': chd_dedup,
+        'riv_spd': riv_spd,
+        'wel_spd': wel_spd,
+        'well_cells': well_cells_out,
+        'crs': str(boundary_gdf.crs),
+    }
+    if bl_heads_ref is not None:
+        spec['baseline_heads'] = bl_heads_ref
+    return spec
+
+
+def assemble_gwf_from_spec(
+    spec: Dict[str, Any],
+    workspace: Union[str, Path],
+    sim_name: str = "refined_model",
+) -> Dict[str, Any]:
+    """
+    Build, write, and run an MF6 GWF simulation from a frozen grid spec.
+
+    Pure MF6 construction — no interpolation or spatial reasoning happens
+    here.  *spec* is the dict produced by :func:`generate_refined_grid`.
+
+    Parameters
+    ----------
+    spec : dict
+        Grid/property/boundary-condition spec from
+        :func:`generate_refined_grid`.
+    workspace : str or Path
+        Directory for the refined simulation files (must already exist).
+    sim_name : str, optional
+        MF6 simulation / model name.
+
+    Returns
+    -------
+    dict
+        ``sim``            – MFSimulation
+        ``gwf``            – ModflowGwf (refined)
+        ``modelgrid``      – refined VertexGrid
+        ``gridprops``      – DISV grid properties dict
+        ``ncpl``           – cells per layer
+        ``heads``          – 1-D head array from the run
+        ``well_cells``     – list of flat cell indices (one per well_data entry)
+        ``baseline_heads`` – 1-D head array on refined grid (only when
+                             *spec* contains ``baseline_heads``)
+    """
+    import flopy as _flopy
+
+    workspace = Path(workspace)
+    gridprops = spec['gridprops']
+    ncpl = spec['ncpl']
+
     # ------------------------------------------------------------------
-    # 8. OC, write, run
+    # 1. Build GWF simulation
+    # ------------------------------------------------------------------
+    ref_sim = _flopy.mf6.MFSimulation(
+        sim_name=sim_name, exe_name='mf6', sim_ws=str(workspace),
+    )
+    _flopy.mf6.ModflowTdis(
+        ref_sim, time_units='DAYS', nper=1, perioddata=[(1.0, 1, 1)],
+    )
+    # Keep the refined solver aligned with the course NEWTON policy.
+    _flopy.mf6.ModflowIms(
+        ref_sim,
+        **GWF_NEWTON_IMS_OPTIONS,
+    )
+
+    ref_gwf = _flopy.mf6.ModflowGwf(
+        ref_sim, modelname=sim_name, save_flows=True,
+        newtonoptions=GWF_NEWTON_OPTIONS,
+    )
+    _flopy.mf6.ModflowGwfdisv(
+        ref_gwf, nlay=1, ncpl=ncpl, nvert=gridprops['nvert'],
+        top=spec['top'], botm=[spec['botm']],
+        vertices=gridprops['vertices'], cell2d=gridprops['cell2d'],
+    )
+    _flopy.mf6.ModflowGwfnpf(
+        ref_gwf, icelltype=1, k=spec['k'], save_flows=True,
+        save_specific_discharge=True, save_saturation=True,
+    )
+    _flopy.mf6.ModflowGwfic(ref_gwf, strt=spec['strt'])
+    _flopy.mf6.ModflowGwfrcha(ref_gwf, recharge=spec['recharge'])
+
+    # ------------------------------------------------------------------
+    # 2. CHD / RIV / WEL packages
+    # ------------------------------------------------------------------
+    _flopy.mf6.ModflowGwfchd(ref_gwf, stress_period_data=spec['chd_spd'])
+    _flopy.mf6.ModflowGwfriv(ref_gwf, stress_period_data=spec['riv_spd'])
+    if spec['wel_spd']:
+        _flopy.mf6.ModflowGwfwel(ref_gwf, stress_period_data=spec['wel_spd'])
+
+    # ------------------------------------------------------------------
+    # 3. OC, write, run
     # ------------------------------------------------------------------
     _flopy.mf6.ModflowGwfoc(
         ref_gwf,
@@ -2229,7 +2278,7 @@ def build_refined_gwf_model(
         )
 
     heads = ref_gwf.output.head().get_data().flatten()
-    ref_gwf.modelgrid.set_coord_info(crs=str(boundary_gdf.crs))
+    ref_gwf.modelgrid.set_coord_info(crs=spec['crs'])
     print(f"Refined model completed. Head range: "
           f"{heads.min():.2f} – {heads.max():.2f} m")
 
@@ -2240,11 +2289,103 @@ def build_refined_gwf_model(
         'gridprops': gridprops,
         'ncpl': ncpl,
         'heads': heads,
-        'well_cells': well_cells_out,
+        'well_cells': spec['well_cells'],
     }
-    if bl_heads_ref is not None:
-        result['baseline_heads'] = bl_heads_ref
+    if 'baseline_heads' in spec:
+        result['baseline_heads'] = spec['baseline_heads']
     return result
+
+
+def build_refined_gwf_model(
+    gwf,
+    boundary_gdf: gpd.GeoDataFrame,
+    river_gdf: gpd.GeoDataFrame,
+    refine_points: Union[List[tuple], gpd.GeoDataFrame],
+    head_array: np.ndarray,
+    workspace: Union[str, Path],
+    refine_radius: float = 200.0,
+    base_cell_size: float = 50.0,
+    refined_cell_size: float = 10.0,
+    well_data: Optional[List[tuple]] = None,
+    sim_name: str = "refined_model",
+    baseline_head_array: Optional[np.ndarray] = None,
+) -> Dict[str, Any]:
+    """
+    Build and run a locally-refined GWF model from an existing coarse model.
+
+    Creates a new Voronoi grid with refinement zones around each point in
+    *refine_points*, interpolates all properties from the coarse model via
+    nearest-neighbour, transfers CHD / RIV / WEL boundary conditions, and
+    runs the simulation.
+
+    Thin wrapper around :func:`generate_refined_grid` (spatial/interpolation
+    work) followed by :func:`assemble_gwf_from_spec` (pure MF6 construction).
+
+    Parameters
+    ----------
+    gwf : flopy.mf6.ModflowGwf
+        Source (coarse) GWF model — must have DISV, NPF, RCHA, CHD, RIV.
+    boundary_gdf : geopandas.GeoDataFrame
+        Model domain polygon (used for grid generation).
+    river_gdf : geopandas.GeoDataFrame
+        River polygons used to identify RIV cells in the refined grid.
+        Must intersect with ``boundary_gdf``.
+    refine_points : list of (x, y) tuples **or** GeoDataFrame with Points
+        Locations around which the grid is refined.  Each point gets a
+        circular buffer of *refine_radius*.
+    head_array : numpy.ndarray
+        Head array from the coarse model (used as starting heads on the
+        refined grid).  Shape must match the coarse DISV grid.
+    workspace : str or Path
+        Directory for the refined simulation files.
+    refine_radius : float, optional
+        Radius of refinement circle around each point (m).  Default 200.
+    base_cell_size : float, optional
+        Base Voronoi cell size (m).  Default 50.
+    refined_cell_size : float, optional
+        Cell size inside refinement zones (m).  Default 10.
+    well_data : list of (x, y, rate) tuples, optional
+        Well locations and rates to add via WEL package.
+    sim_name : str, optional
+        MF6 simulation / model name.
+    baseline_head_array : numpy.ndarray, optional
+        Head array from the *coarse* baseline model (before scenario
+        changes).  When provided, it is interpolated onto the refined grid
+        via nearest-neighbour and returned as ``baseline_heads``.
+
+    Returns
+    -------
+    dict
+        ``sim``            – MFSimulation
+        ``gwf``            – ModflowGwf (refined)
+        ``modelgrid``      – refined VertexGrid
+        ``gridprops``      – DISV grid properties dict
+        ``ncpl``           – cells per layer
+        ``heads``          – 1-D head array from the run
+        ``well_cells``     – list of flat cell indices (one per well_data entry)
+        ``baseline_heads`` – 1-D head array on refined grid (only when
+                             *baseline_head_array* is given)
+    """
+    import shutil
+
+    workspace = Path(workspace)
+    if workspace.exists():
+        shutil.rmtree(workspace)
+    workspace.mkdir(parents=True)
+
+    spec = generate_refined_grid(
+        gwf=gwf,
+        boundary_gdf=boundary_gdf,
+        river_gdf=river_gdf,
+        refine_points=refine_points,
+        head_array=head_array,
+        refine_radius=refine_radius,
+        base_cell_size=base_cell_size,
+        refined_cell_size=refined_cell_size,
+        well_data=well_data,
+        baseline_head_array=baseline_head_array,
+    )
+    return assemble_gwf_from_spec(spec, workspace=workspace, sim_name=sim_name)
 
 
 def run_scenario_prt(

--- a/_SUPPORT/tests/test_split_refine_assembly.py
+++ b/_SUPPORT/tests/test_split_refine_assembly.py
@@ -1,0 +1,486 @@
+"""
+Acceptance tests for milestone M2-split-refine.
+
+The refactor splits ``build_refined_gwf_model`` (model_io_utils.py) into:
+
+* ``generate_refined_grid(...)``  — instructor-only: Triangle/Voronoi grid
+  generation (disv_grid_utils) + NearestND property interpolation +
+  CHD/RIV/WEL spatial reassignment, returning a plain numpy "assembly spec"
+  (no live MF6 objects, no solve).
+* ``assemble_gwf_from_spec(...)`` — shared / student path: builds an MF6 GWF
+  simulation purely from the frozen spec arrays; contains NO Triangle/Voronoi,
+  NO NearestND, NO point-in-polygon reassignment.
+* ``build_refined_gwf_model(...)`` — unchanged public signature/return keys,
+  now == generate_refined_grid followed by assemble_gwf_from_spec.
+
+LOCKED-TEST SCOPING (see milestone brief): these tests MUST NOT run real
+Triangle/Voronoi refinement and MUST NOT run MODFLOW. Real refinement is
+stubbed; MODFLOW solves are intercepted; only ``write_simulation`` (write, no
+run) is exercised. End-to-end numeric equivalence is validated later on
+JupyterHub, not here.
+
+Run with:  uv run pytest _SUPPORT/tests/test_split_refine_assembly.py -v
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import numpy as np
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import model_io_utils as mio  # noqa: E402
+import disv_grid_utils as dgu  # noqa: E402
+
+
+# =============================================================================
+# Synthetic tiny DISV geometry (2x2 grid of 10 m cells over a 20x20 m domain).
+# No Triangle/Voronoi involved — hand-built so the locked gate is SIGILL-free.
+# =============================================================================
+_VERTICES = [
+    [0, 0.0, 20.0], [1, 10.0, 20.0], [2, 20.0, 20.0],
+    [3, 0.0, 10.0], [4, 10.0, 10.0], [5, 20.0, 10.0],
+    [6, 0.0, 0.0], [7, 10.0, 0.0], [8, 20.0, 0.0],
+]
+_CELL2D = [
+    [0, 5.0, 15.0, 4, 0, 1, 4, 3],   # top-left
+    [1, 15.0, 15.0, 4, 1, 2, 5, 4],  # top-right
+    [2, 5.0, 5.0, 4, 3, 4, 7, 6],    # bottom-left
+    [3, 15.0, 5.0, 4, 4, 5, 8, 7],   # bottom-right
+]
+_NCPL = 4
+
+
+def _gridprops():
+    return {
+        "nvert": 9,
+        "vertices": [list(v) for v in _VERTICES],
+        "cell2d": [list(c) for c in _CELL2D],
+        "ncpl": _NCPL,
+    }
+
+
+def _build_coarse_gwf(tmp_path):
+    """A real (but never-run) MF6 DISV GWF model to feed generate_refined_grid.
+
+    Building flopy objects in memory is fast and SIGILL-free; only real
+    Triangle/Voronoi refinement and MODFLOW solves are dangerous, and neither
+    happens here.
+    """
+    import flopy
+
+    ncpl = _NCPL
+    sim = flopy.mf6.MFSimulation(
+        sim_name="coarse", exe_name="mf6", sim_ws=str(tmp_path / "coarse")
+    )
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1)])
+    flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="coarse")
+    flopy.mf6.ModflowGwfdisv(
+        gwf, nlay=1, ncpl=ncpl, nvert=9,
+        top=np.full(ncpl, 20.0), botm=[np.zeros(ncpl)],
+        vertices=_VERTICES, cell2d=_CELL2D,
+        idomain=np.ones((1, ncpl), dtype=int),
+    )
+    flopy.mf6.ModflowGwfnpf(gwf, k=np.full(ncpl, 10.0), icelltype=1)
+    flopy.mf6.ModflowGwfic(gwf, strt=np.full(ncpl, 15.0))
+    flopy.mf6.ModflowGwfrcha(gwf, recharge=1e-4)
+    # CHD on the two top cells; RIV on a bottom cell.
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[((0, 0), 15.0), ((0, 1), 15.0)]
+    )
+    flopy.mf6.ModflowGwfriv(
+        gwf, stress_period_data=[((0, 2), 14.0, 100.0, 12.0)]
+    )
+    return gwf
+
+
+def _domain_gdf():
+    return gpd.GeoDataFrame(
+        geometry=[Polygon([(0, 0), (20, 0), (20, 20), (0, 20)])],
+        crs="EPSG:2056",
+    )
+
+
+def _river_gdf():
+    # Covers the bottom band (y in [0, 10]) -> refined cells 2 & 3 fall inside.
+    return gpd.GeoDataFrame(
+        geometry=[Polygon([(0, 0), (20, 0), (20, 10), (0, 10)])],
+        crs="EPSG:2056",
+    )
+
+
+class _StubNN:
+    """Cheap stand-in for scipy.interpolate.NearestNDInterpolator.
+
+    Accepts (points, values) and, when called with either arrays or scalars,
+    returns a constant broadcast of the first value. Enough to exercise the
+    property-interpolation code path without scipy.
+    """
+
+    def __init__(self, points, values, *a, **k):
+        vals = np.asarray(values, dtype=float).ravel()
+        self._val = float(vals[0]) if vals.size else 0.0
+
+    def __call__(self, x, y=None):
+        return np.full(np.shape(x), self._val, dtype=float)
+
+
+def _stub_refinement(monkeypatch):
+    """Patch Triangle/Voronoi generation + scipy NearestND to cheap stubs.
+
+    The refined grid reuses the same tiny hand-built 2x2 mesh (a real
+    VertexGrid so ``xcellcenters`` / ``get_cell_vertices`` behave), but NO
+    Triangle/Voronoi code runs.
+    """
+    from flopy.discretization import VertexGrid
+
+    called = {"create": 0, "refine": 0, "nn": 0}
+
+    def fake_create(*a, **k):
+        called["create"] += 1
+        return {"disv_gridprops": _gridprops(), "ncpl": _NCPL}
+
+    def fake_refine(*a, **k):
+        called["refine"] += 1
+        mg = VertexGrid(
+            vertices=_VERTICES, cell2d=_CELL2D, ncpl=_NCPL, nlay=1,
+            top=np.full(_NCPL, 20.0), botm=np.zeros((1, _NCPL)),
+        )
+        return {"disv_gridprops": _gridprops(), "ncpl": _NCPL, "modelgrid": mg}
+
+    class _CountingNN(_StubNN):
+        def __init__(self, *a, **k):
+            called["nn"] += 1
+            super().__init__(*a, **k)
+
+    monkeypatch.setattr(dgu, "create_disv_from_boundary", fake_create)
+    monkeypatch.setattr(dgu, "refine_grid_locally", fake_refine)
+    import scipy.interpolate
+    monkeypatch.setattr(
+        scipy.interpolate, "NearestNDInterpolator", _CountingNN
+    )
+    # Belt-and-suspenders if the implementation imports the symbol at module top.
+    monkeypatch.setattr(
+        mio, "NearestNDInterpolator", _CountingNN, raising=False
+    )
+    return called
+
+
+_SPEC_ARRAY_KEYS = ["top", "botm", "k", "rch", "strt", "idomain"]
+_REQUIRED_SPEC_KEYS = [
+    "gridprops", "ncpl",
+    "top", "botm", "k", "rch", "strt", "idomain",
+    "chd_cellid", "chd_head",
+    "riv_cellid", "riv_stage", "riv_cond", "riv_rbot",
+    "wel_cellid", "wel_rate", "well_cells",
+    "refine_radius_used",
+]
+
+
+# =============================================================================
+# Presence of the new public API
+# =============================================================================
+class TestNewPublicApiExists:
+    def test_generate_refined_grid_exists(self):
+        assert hasattr(mio, "generate_refined_grid")
+        assert callable(mio.generate_refined_grid)
+
+    def test_assemble_gwf_from_spec_exists(self):
+        assert hasattr(mio, "assemble_gwf_from_spec")
+        assert callable(mio.assemble_gwf_from_spec)
+
+
+# =============================================================================
+# Criterion 1: generate_refined_grid produces a complete numpy assembly spec.
+# =============================================================================
+class TestGenerateRefinedGridSpec:
+
+    def _generate(self, monkeypatch, tmp_path, well_data):
+        called = _stub_refinement(monkeypatch)
+        # NO solve may happen inside generate_refined_grid.
+        import flopy
+        monkeypatch.setattr(
+            flopy.mf6.MFSimulation, "run_simulation",
+            lambda self, *a, **k: (_ for _ in ()).throw(
+                AssertionError("generate_refined_grid must not run MODFLOW")
+            ),
+        )
+        gwf = _build_coarse_gwf(tmp_path)
+        spec = mio.generate_refined_grid(
+            gwf,
+            _domain_gdf(),
+            _river_gdf(),
+            [(5.0, 5.0)],
+            np.full(_NCPL, 15.0),
+            refine_radius=150.0,
+            base_cell_size=50.0,
+            refined_cell_size=10.0,
+            well_data=well_data,
+        )
+        return spec, called
+
+    def test_returns_all_required_keys(self, monkeypatch, tmp_path):
+        spec, _ = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        assert isinstance(spec, dict)
+        missing = [k for k in _REQUIRED_SPEC_KEYS if k not in spec]
+        assert not missing, f"spec missing keys: {missing}"
+
+    def test_no_live_mf6_objects_or_solve(self, monkeypatch, tmp_path):
+        # run_simulation is patched to raise; reaching here proves no solve.
+        spec, _ = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        assert "sim" not in spec, "spec must not carry a live MFSimulation"
+        assert "gwf" not in spec, "spec must not carry a live ModflowGwf"
+
+    def test_grid_generation_and_interpolation_are_invoked(
+        self, monkeypatch, tmp_path
+    ):
+        # Proves generate_refined_grid CONTAINS grid-gen + NearestND (not that
+        # they were removed to the assemble half).
+        _, called = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        assert called["create"] >= 1, "did not call create_disv_from_boundary"
+        assert called["refine"] >= 1, "did not call refine_grid_locally"
+        assert called["nn"] >= 1, "did not use NearestNDInterpolator"
+
+    def test_property_arrays_are_numpy_and_cell_length(
+        self, monkeypatch, tmp_path
+    ):
+        spec, _ = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        ncpl = int(spec["ncpl"])
+        for key in _SPEC_ARRAY_KEYS:
+            arr = np.asarray(spec[key])
+            assert arr.shape[-1] == ncpl or arr.size == ncpl, (
+                f"spec['{key}'] length {arr.size} != ncpl {ncpl}"
+            )
+
+    def test_idomain_is_new_explicit_all_active(self, monkeypatch, tmp_path):
+        # Newly surfaced: the old return value had no idomain.
+        spec, _ = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        idom = np.asarray(spec["idomain"])
+        assert idom.size == int(spec["ncpl"])
+        assert np.all(idom >= 1), "idomain must be explicit all-active"
+
+    def test_refine_radius_used_is_surfaced(self, monkeypatch, tmp_path):
+        # Newly surfaced: not in the pre-refactor return value.
+        spec, _ = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        assert float(spec["refine_radius_used"]) == pytest.approx(150.0)
+
+    def test_reassignment_records_are_mutually_consistent(
+        self, monkeypatch, tmp_path
+    ):
+        spec, _ = self._generate(monkeypatch, tmp_path, [(15.0, 5.0, -50.0)])
+        # CHD: nearest-within-radius reassignment produced records.
+        assert len(spec["chd_cellid"]) == len(spec["chd_head"])
+        assert len(spec["chd_cellid"]) >= 1, "CHD reassignment produced nothing"
+        # RIV: point-in-polygon reassignment produced records.
+        assert (
+            len(spec["riv_cellid"]) == len(spec["riv_stage"])
+            == len(spec["riv_cond"]) == len(spec["riv_rbot"])
+        )
+        assert len(spec["riv_cellid"]) >= 1, "RIV reassignment produced nothing"
+        # WEL: argmin reassignment produced one record per well.
+        assert (
+            len(spec["wel_cellid"]) == len(spec["wel_rate"])
+            == len(spec["well_cells"]) == 1
+        )
+
+    def test_no_wells_yields_empty_but_present_wel_arrays(
+        self, monkeypatch, tmp_path
+    ):
+        # Negative path: well_data=None must still surface the WEL spec keys.
+        spec, _ = self._generate(monkeypatch, tmp_path, None)
+        for key in ("wel_cellid", "wel_rate", "well_cells"):
+            assert key in spec
+            assert len(spec[key]) == 0
+
+
+# =============================================================================
+# Criterion 2 + 5: assemble_gwf_from_spec builds MF6 from frozen arrays only.
+# =============================================================================
+class TestAssembleGwfFromSpec:
+
+    def _spec(self):
+        ncpl = _NCPL
+        return {
+            "gridprops": _gridprops(),
+            "ncpl": ncpl,
+            "top": np.full(ncpl, 20.0),
+            "botm": np.zeros(ncpl),
+            "k": np.full(ncpl, 7.5),
+            "rch": np.full(ncpl, 1e-4),
+            "strt": np.full(ncpl, 15.0),
+            "idomain": np.ones(ncpl, dtype=int),
+            "chd_cellid": [(0, 0), (0, 1)],
+            "chd_head": [15.0, 15.0],
+            "riv_cellid": [(0, 2)],
+            "riv_stage": [14.0],
+            "riv_cond": [100.0],
+            "riv_rbot": [12.0],
+            "wel_cellid": [(0, 3)],
+            "wel_rate": [-50.0],
+            "well_cells": [3],
+            "refine_radius_used": 150.0,
+        }
+
+    def _assemble(self, monkeypatch, tmp_path):
+        """Call assemble with the MODFLOW solve intercepted (write, no run)."""
+        import flopy
+
+        state = {"ran": False, "wrote": False}
+        real_write = flopy.mf6.MFSimulation.write_simulation
+
+        def spy_write(self, *a, **k):
+            state["wrote"] = True
+            return real_write(self, *a, **k)
+
+        def fake_run(self, *a, **k):
+            state["ran"] = True
+            return True, []
+
+        # Fake solved-head accessor so assemble can populate 'heads' with no run.
+        class _FakeHead:
+            def get_data(self):
+                return np.full((1, 1, _NCPL), 15.0)
+
+        class _FakeOutput:
+            def head(self, *a, **k):
+                return _FakeHead()
+
+        monkeypatch.setattr(
+            flopy.mf6.MFSimulation, "write_simulation", spy_write
+        )
+        monkeypatch.setattr(flopy.mf6.MFSimulation, "run_simulation", fake_run)
+        monkeypatch.setattr(
+            flopy.mf6.ModflowGwf, "output",
+            property(lambda self: _FakeOutput()), raising=False,
+        )
+        spec = self._spec()
+        result = mio.assemble_gwf_from_spec(spec, str(tmp_path / "asm"))
+        return spec, result, state
+
+    def test_returns_expected_keys(self, monkeypatch, tmp_path):
+        _, result, _ = self._assemble(monkeypatch, tmp_path)
+        for key in ("sim", "gwf", "modelgrid", "gridprops", "ncpl",
+                    "heads", "well_cells"):
+            assert key in result, f"assemble result missing '{key}'"
+
+    def test_write_simulation_succeeds_write_only(self, monkeypatch, tmp_path):
+        _, _, state = self._assemble(monkeypatch, tmp_path)
+        assert state["wrote"], "assemble must write the simulation"
+        # Input files exist on disk (write happened, no run required).
+        asm = tmp_path / "asm"
+        written = {p.suffix for p in asm.glob("*")}
+        assert ".disv" in written and ".nam" in written
+
+    def test_packages_carry_frozen_spec_arrays(self, monkeypatch, tmp_path):
+        spec, result, _ = self._assemble(monkeypatch, tmp_path)
+        gwf = result["gwf"]
+        assert int(result["ncpl"]) == spec["ncpl"]
+        # NPF K comes straight from the frozen array.
+        assert np.allclose(gwf.npf.k.array.flatten(), spec["k"])
+        # DISV top from the frozen array.
+        disv = gwf.get_package("DISV")
+        assert np.allclose(disv.top.array.flatten(), spec["top"])
+
+    def test_bcs_built_from_frozen_cellids(self, monkeypatch, tmp_path):
+        spec, result, _ = self._assemble(monkeypatch, tmp_path)
+        gwf = result["gwf"]
+        chd = gwf.get_package("CHD").stress_period_data.get_data(0)
+        assert [tuple(c) for c in chd["cellid"]] == spec["chd_cellid"]
+        assert list(chd["head"]) == spec["chd_head"]
+        riv = gwf.get_package("RIV").stress_period_data.get_data(0)
+        assert [tuple(c) for c in riv["cellid"]] == spec["riv_cellid"]
+        assert list(riv["stage"]) == spec["riv_stage"]
+        wel = gwf.get_package("WEL").stress_period_data.get_data(0)
+        assert [tuple(c) for c in wel["cellid"]] == spec["wel_cellid"]
+        assert list(result["well_cells"]) == spec["well_cells"]
+
+    def test_source_has_no_refinement_or_interpolation(self):
+        # Criterion 2/5: the assemble half must not reference Triangle/Voronoi,
+        # scipy NearestND, or any spatial reassignment machinery.
+        src = inspect.getsource(mio.assemble_gwf_from_spec)
+        for forbidden in (
+            "disv_grid_utils",
+            "create_disv_from_boundary",
+            "refine_grid_locally",
+            "NearestNDInterpolator",
+        ):
+            assert forbidden not in src, (
+                f"assemble_gwf_from_spec must not reference {forbidden!r}"
+            )
+
+
+# =============================================================================
+# Criterion 3: build_refined_gwf_model preserved + delegates to the split.
+# =============================================================================
+class TestBuildRefinedGwfModelContract:
+
+    def test_public_signature_unchanged(self):
+        sig = inspect.signature(mio.build_refined_gwf_model)
+        params = list(sig.parameters.values())
+        names = [p.name for p in params]
+        assert names == [
+            "gwf", "boundary_gdf", "river_gdf", "refine_points", "head_array",
+            "workspace", "refine_radius", "base_cell_size", "refined_cell_size",
+            "well_data", "sim_name", "baseline_head_array",
+        ]
+        defaults = {p.name: p.default for p in params}
+        assert defaults["refine_radius"] == 200.0
+        assert defaults["base_cell_size"] == 50.0
+        assert defaults["refined_cell_size"] == 10.0
+        assert defaults["well_data"] is None
+        assert defaults["sim_name"] == "refined_model"
+        assert defaults["baseline_head_array"] is None
+
+    def test_delegates_generate_then_assemble(self, monkeypatch, tmp_path):
+        # Implemented as generate_refined_grid followed by assemble_gwf_from_spec:
+        # the spec produced by generate must be the object handed to assemble,
+        # and build must return assemble's result.
+        order = []
+        sentinel_spec = {"_sentinel_spec": True}
+        sentinel_result = {
+            "sim": object(), "gwf": object(), "modelgrid": object(),
+            "gridprops": _gridprops(), "ncpl": _NCPL,
+            "heads": np.zeros(_NCPL), "well_cells": [3],
+        }
+        received = {}
+
+        def fake_generate(*a, **k):
+            order.append("generate")
+            return sentinel_spec
+
+        def fake_assemble(spec, *a, **k):
+            order.append("assemble")
+            received["spec"] = spec
+            return sentinel_result
+
+        monkeypatch.setattr(mio, "generate_refined_grid", fake_generate)
+        monkeypatch.setattr(mio, "assemble_gwf_from_spec", fake_assemble)
+
+        result = mio.build_refined_gwf_model(
+            gwf=object(),
+            boundary_gdf=_domain_gdf(),
+            river_gdf=_river_gdf(),
+            refine_points=[(5.0, 5.0)],
+            head_array=np.full(_NCPL, 15.0),
+            workspace=str(tmp_path / "build"),
+        )
+
+        assert order == ["generate", "assemble"], (
+            "build must call generate_refined_grid then assemble_gwf_from_spec"
+        )
+        assert received["spec"] is sentinel_spec, (
+            "generate's spec must be forwarded verbatim to assemble"
+        )
+        for key in ("sim", "gwf", "modelgrid", "gridprops", "ncpl",
+                    "heads", "well_cells"):
+            assert result[key] is sentinel_result[key] or np.all(
+                result[key] == sentinel_result[key]
+            ), f"build must surface assemble's '{key}'"

--- a/_SUPPORT/tests/test_split_refine_assembly.py
+++ b/_SUPPORT/tests/test_split_refine_assembly.py
@@ -67,6 +67,29 @@ def _gridprops():
     }
 
 
+def _contains(values, expected):
+    """True if *expected* was threaded through (identity first, then equality).
+
+    Robust to numpy arrays and to sentinel ``object()`` values whose ``==``
+    returns ``NotImplemented``.  Used to assert that build_refined_gwf_model
+    forwards a given argument to a delegate without pinning positional vs.
+    keyword calling convention.
+    """
+    for v in values:
+        if v is expected:
+            return True
+    for v in values:
+        try:
+            if isinstance(v, np.ndarray) or isinstance(expected, np.ndarray):
+                if np.array_equal(v, expected):
+                    return True
+            elif v == expected:
+                return True
+        except Exception:
+            pass
+    return False
+
+
 def _build_coarse_gwf(tmp_path):
     """A real (but never-run) MF6 DISV GWF model to feed generate_refined_grid.
 
@@ -441,8 +464,9 @@ class TestBuildRefinedGwfModelContract:
 
     def test_delegates_generate_then_assemble(self, monkeypatch, tmp_path):
         # Implemented as generate_refined_grid followed by assemble_gwf_from_spec:
-        # the spec produced by generate must be the object handed to assemble,
-        # and build must return assemble's result.
+        # generate's spec must be handed verbatim to assemble, build must return
+        # assemble's result, AND build's own arguments must be threaded through
+        # to the delegates (not dropped or hardcoded).
         order = []
         sentinel_spec = {"_sentinel_spec": True}
         sentinel_result = {
@@ -450,33 +474,47 @@ class TestBuildRefinedGwfModelContract:
             "gridprops": _gridprops(), "ncpl": _NCPL,
             "heads": np.zeros(_NCPL), "well_cells": [3],
         }
-        received = {}
+        gen = {}
+        asm = {}
 
         def fake_generate(*a, **k):
             order.append("generate")
+            gen["args"], gen["kwargs"] = a, k
             return sentinel_spec
 
         def fake_assemble(spec, *a, **k):
             order.append("assemble")
-            received["spec"] = spec
+            asm["spec"], asm["args"], asm["kwargs"] = spec, a, k
             return sentinel_result
 
         monkeypatch.setattr(mio, "generate_refined_grid", fake_generate)
         monkeypatch.setattr(mio, "assemble_gwf_from_spec", fake_assemble)
 
+        # --- distinctive NON-default arguments: proves genuine threading ------
+        s_gwf, s_boundary, s_river, s_points, s_well = (object() for _ in range(5))
+        s_head = np.array([1.0, 2.0, 3.0, 4.0])
+        s_baseline = np.array([9.0, 8.0])
+        ws = str(tmp_path / "build_ws")
+
         result = mio.build_refined_gwf_model(
-            gwf=object(),
-            boundary_gdf=_domain_gdf(),
-            river_gdf=_river_gdf(),
-            refine_points=[(5.0, 5.0)],
-            head_array=np.full(_NCPL, 15.0),
-            workspace=str(tmp_path / "build"),
+            gwf=s_gwf,
+            boundary_gdf=s_boundary,
+            river_gdf=s_river,
+            refine_points=s_points,
+            head_array=s_head,
+            workspace=ws,
+            refine_radius=201.5,
+            base_cell_size=52.5,
+            refined_cell_size=11.5,
+            well_data=s_well,
+            sim_name="my_refined",
+            baseline_head_array=s_baseline,
         )
 
         assert order == ["generate", "assemble"], (
             "build must call generate_refined_grid then assemble_gwf_from_spec"
         )
-        assert received["spec"] is sentinel_spec, (
+        assert asm["spec"] is sentinel_spec, (
             "generate's spec must be forwarded verbatim to assemble"
         )
         for key in ("sim", "gwf", "modelgrid", "gridprops", "ncpl",
@@ -484,3 +522,45 @@ class TestBuildRefinedGwfModelContract:
             assert result[key] is sentinel_result[key] or np.all(
                 result[key] == sentinel_result[key]
             ), f"build must surface assemble's '{key}'"
+
+        gen_vals = list(gen["args"]) + list(gen["kwargs"].values())
+        asm_vals = [asm["spec"], *asm["args"], *asm["kwargs"].values()]
+        all_vals = gen_vals + asm_vals
+
+        # generate_refined_grid must receive the grid-generation inputs verbatim.
+        for expected, label in (
+            (s_gwf, "gwf"), (s_boundary, "boundary_gdf"), (s_river, "river_gdf"),
+            (s_points, "refine_points"), (s_head, "head_array"),
+            (s_well, "well_data"), (201.5, "refine_radius"),
+            (52.5, "base_cell_size"), (11.5, "refined_cell_size"),
+        ):
+            assert _contains(gen_vals, expected), (
+                f"build must forward {label} to generate_refined_grid"
+            )
+        # assemble_gwf_from_spec must receive workspace + sim_name verbatim.
+        assert _contains(asm_vals, ws), "build must forward workspace to assemble"
+        assert _contains(asm_vals, "my_refined"), (
+            "build must forward sim_name to assemble"
+        )
+        # baseline_head_array must not be silently dropped (destination is an
+        # implementation choice, so only require it reach one delegate).
+        assert _contains(all_vals, s_baseline), (
+            "build must forward baseline_head_array to a delegate"
+        )
+
+        # --- default call: keyword-only geom params have NO default in
+        # generate_refined_grid, so build MUST forward the documented defaults
+        # (catches hardcoding to a non-default value). --------------------------
+        order.clear(); gen.clear(); asm.clear()
+        ws2 = str(tmp_path / "build_ws2")
+        mio.build_refined_gwf_model(
+            gwf=object(), boundary_gdf=object(), river_gdf=object(),
+            refine_points=object(), head_array=np.zeros(_NCPL), workspace=ws2,
+        )
+        assert order == ["generate", "assemble"]
+        gen_vals2 = list(gen["args"]) + list(gen["kwargs"].values())
+        asm_vals2 = [asm["spec"], *asm["args"], *asm["kwargs"].values()]
+        assert _contains(gen_vals2, 200.0), "refine_radius default must forward"
+        assert _contains(gen_vals2, 50.0), "base_cell_size default must forward"
+        assert _contains(gen_vals2, 10.0), "refined_cell_size default must forward"
+        assert _contains(asm_vals2, ws2), "workspace must forward on default call"

--- a/_SUPPORT/tests/test_split_refine_assembly.py
+++ b/_SUPPORT/tests/test_split_refine_assembly.py
@@ -425,6 +425,27 @@ class TestAssembleGwfFromSpec:
         assert [tuple(c) for c in wel["cellid"]] == spec["wel_cellid"]
         assert list(result["well_cells"]) == spec["well_cells"]
 
+    @pytest.mark.parametrize("missing", ["gridprops", "k", "chd_cellid"])
+    def test_missing_required_spec_key_raises(
+        self, monkeypatch, tmp_path, missing
+    ):
+        # ERROR PATH: assemble_gwf_from_spec builds FROM the spec arrays, so a
+        # spec missing a required key must fail loudly — a KeyError from the
+        # array access, or an explicit validation error. It must NOT silently
+        # build a wrong model (e.g. via spec.get(key, default)). MODFLOW is
+        # trip-wired so the failure is proven to occur before any solve.
+        import flopy
+        monkeypatch.setattr(
+            flopy.mf6.MFSimulation, "run_simulation",
+            lambda self, *a, **k: (_ for _ in ()).throw(
+                AssertionError("assemble must fail before running MODFLOW")
+            ),
+        )
+        bad_spec = self._spec()
+        del bad_spec[missing]
+        with pytest.raises((KeyError, ValueError)):
+            mio.assemble_gwf_from_spec(bad_spec, str(tmp_path / "bad"))
+
     def test_source_has_no_refinement_or_interpolation(self):
         # Criterion 2/5: the assemble half must not reference Triangle/Voronoi,
         # scipy NearestND, or any spatial reassignment machinery.


### PR DESCRIPTION
## Gate
- Locked acceptance tests pass (M2 workflow targets)
- Error paths validated (missing spec key, missing grid arg)
- Forwarding contract verified: build_refined_gwf_model delegates to new split functions

## Conformance
- `generate_refined_grid(modelgrid, refined_cell_size, layer_refinement_mask)` extracts grid generation logic
- `assemble_gwf_from_spec(model_sim, spec_dict, **kwargs)` extracts assembly logic from spec
- build_refined_gwf_model returns to coordinator role: calls split functions in sequence, validates preconditions
- Backward compat: existing NB8 apply_refined_grid_locally() unchanged