### PR TITLE
Pinned flow-model loader: freeze spec to NPZ + load+assemble with no regeneration

### DIFF
--- a/_SUPPORT/src/model_io_utils.py
+++ b/_SUPPORT/src/model_io_utils.py
@@ -2581,7 +2581,9 @@ def _decode_flow_spec_from_npz(arrays: Dict[str, np.ndarray]) -> Dict[str, Any]:
         spec[key] = [tuple(int(x) for x in row) for row in arrays[key]]
 
     for key in _FLOW_SPEC_VALUE_FLOAT_KEYS + _FLOW_SPEC_VALUE_INT_KEYS:
-        spec[key] = arrays[key]
+        spec[key] = (
+            [int(x) for x in arrays[key]] if key == "well_cells" else arrays[key]
+        )
 
     for key in _FLOW_SPEC_OPTIONAL_STR_KEYS:
         spec[key] = str(arrays[key]) if key in arrays else None

--- a/_SUPPORT/src/model_io_utils.py
+++ b/_SUPPORT/src/model_io_utils.py
@@ -23,6 +23,11 @@ Functions:
     build_refined_gwf_model: Build locally-refined GWF model from coarse model
     build_prt_model: Build PRT particle-tracking simulation from GWF model
     load_prt_results: Load and classify PRT tracking results
+    freeze_flow_spec: Encode a refined-grid spec (incl. ragged DISV gridprops)
+        into an NPZ + hash-verified manifest via case_artifact_lock
+    load_flow_spec: Reconstruct a frozen flow spec from its NPZ/manifest pair
+    load_pinned_flow_model: Load a per-group pinned flow spec and assemble it
+        into a runnable GWF model without re-deriving geometry
 
 Author: Applied Groundwater Modelling Course
 """
@@ -2413,6 +2418,362 @@ def build_refined_gwf_model(
         well_data=well_data,
         baseline_head_array=baseline_head_array,
     )
+    return assemble_gwf_from_spec(spec, workspace=workspace, sim_name=sim_name)
+
+
+# =============================================================================
+# Pinned flow spec codec (freeze_flow_spec / load_flow_spec / load_pinned_flow_model)
+#
+# These functions let the GRADED path rebuild the refined MF6/DISV model from
+# a frozen, hash-verified .npz of plain numpy arrays -- without re-running
+# Triangle/Voronoi grid generation (disv_grid_utils) or scipy NearestND
+# interpolation. They compose the already-shipped case_artifact_lock (hash
+# manifest write/verify) with assemble_gwf_from_spec (pure MF6 construction).
+#
+# Spec schema (see generate_refined_grid docstring): 'gridprops', 'ncpl',
+# 'top', 'botm', 'k', 'rch', 'strt', 'idomain', 'chd_cellid', 'chd_head',
+# 'riv_cellid', 'riv_stage', 'riv_cond', 'riv_rbot', 'wel_cellid', 'wel_rate',
+# 'well_cells', 'refine_radius_used', 'crs', and (optionally) 'baseline_heads'.
+# 'gridprops' (flopy.utils.cvfdutil.get_disv_gridprops output) has keys
+# 'ncpl', 'nvert', 'vertices' (rectangular, one (i, x, y) row per vertex), and
+# 'cell2d' (RAGGED -- one [icell2d, xc, yc, nverts, *vertex_ids] row per cell,
+# row length = 4 + nverts, which varies cell to cell).
+# =============================================================================
+
+# Keys whose values are already plain 1-D arrays of length ncpl.
+_FLOW_SPEC_FLAT_ARRAY_KEYS = ("top", "botm", "k", "rch", "strt", "idomain")
+# Keys holding a list of (layer, cell) cellid tuples -> encoded as (n, 2) int arrays.
+_FLOW_SPEC_CELLID_KEYS = ("chd_cellid", "riv_cellid", "wel_cellid")
+# Keys holding a 1-D list of floats parallel to a cellid key above.
+_FLOW_SPEC_VALUE_FLOAT_KEYS = ("chd_head", "riv_stage", "riv_cond", "riv_rbot", "wel_rate")
+# Keys holding a 1-D list of flat cell indices (ints), not cellid tuples.
+_FLOW_SPEC_VALUE_INT_KEYS = ("well_cells",)
+# Optional keys, round-tripped only when present (and not None) in the spec.
+_FLOW_SPEC_OPTIONAL_STR_KEYS = ("crs",)
+_FLOW_SPEC_OPTIONAL_FLOAT_ARRAY_KEYS = ("baseline_heads",)
+
+_FLOW_SPEC_REQUIRED_KEYS = (
+    ("gridprops", "ncpl", "refine_radius_used")
+    + _FLOW_SPEC_FLAT_ARRAY_KEYS
+    + _FLOW_SPEC_CELLID_KEYS
+    + _FLOW_SPEC_VALUE_FLOAT_KEYS
+    + _FLOW_SPEC_VALUE_INT_KEYS
+)
+
+
+def _encode_gridprops_for_npz(gridprops: Dict[str, Any]) -> Dict[str, np.ndarray]:
+    """Encode a DISV ``gridprops`` dict (as returned by
+    ``flopy.utils.cvfdutil.get_disv_gridprops``) into NPZ-safe plain numpy
+    arrays, preserving the RAGGED ``cell2d`` row lengths as a CSR-style
+    (flat values + row lengths) pair.
+    """
+    vertices = np.asarray(
+        [[float(v[0]), float(v[1]), float(v[2])] for v in gridprops["vertices"]],
+        dtype=np.float64,
+    )
+    cell2d_rows = [[float(x) for x in row] for row in gridprops["cell2d"]]
+    cell2d_lengths = np.array([len(row) for row in cell2d_rows], dtype=np.int64)
+    cell2d_flat = (
+        np.concatenate([np.asarray(row, dtype=np.float64) for row in cell2d_rows])
+        if cell2d_rows
+        else np.zeros(0, dtype=np.float64)
+    )
+    return {
+        "gridprops__ncpl": np.array(int(gridprops["ncpl"]), dtype=np.int64),
+        "gridprops__nvert": np.array(int(gridprops["nvert"]), dtype=np.int64),
+        "gridprops__vertices": vertices,
+        "gridprops__cell2d_flat": cell2d_flat,
+        "gridprops__cell2d_lengths": cell2d_lengths,
+    }
+
+
+def _decode_gridprops_from_npz(arrays: Dict[str, np.ndarray]) -> Dict[str, Any]:
+    """Inverse of :func:`_encode_gridprops_for_npz` -- rebuilds a ``gridprops``
+    dict with the exact ragged ``cell2d`` row lengths restored, ready to pass
+    straight into ``flopy.mf6.ModflowGwfdisv``.
+    """
+    vertices_arr = arrays["gridprops__vertices"]
+    vertices = [
+        (int(round(row[0])), float(row[1]), float(row[2])) for row in vertices_arr
+    ]
+
+    lengths = arrays["gridprops__cell2d_lengths"]
+    flat = arrays["gridprops__cell2d_flat"]
+    cell2d = []
+    idx = 0
+    for n in lengths:
+        n = int(n)
+        row = flat[idx : idx + n]
+        idx += n
+        icell2d = int(round(row[0]))
+        xc, yc = float(row[1]), float(row[2])
+        nverts = int(round(row[3]))
+        ivert_ids = [int(round(v)) for v in row[4 : 4 + nverts]]
+        cell2d.append([icell2d, xc, yc, nverts] + ivert_ids)
+
+    return {
+        "ncpl": int(arrays["gridprops__ncpl"]),
+        "nvert": int(arrays["gridprops__nvert"]),
+        "vertices": vertices,
+        "cell2d": cell2d,
+    }
+
+
+def _encode_flow_spec_for_npz(spec: Dict[str, Any]) -> Dict[str, np.ndarray]:
+    """Encode a ``generate_refined_grid`` spec into a flat dict of NPZ-safe
+    (non-object-dtype) numpy arrays.
+
+    Raises
+    ------
+    KeyError
+        If *spec* is missing any of the fields documented in
+        ``generate_refined_grid`` / ``assemble_gwf_from_spec``.
+    """
+    missing = [k for k in _FLOW_SPEC_REQUIRED_KEYS if k not in spec]
+    if missing:
+        raise KeyError(f"flow spec is missing required key(s): {sorted(missing)!r}")
+
+    arrays: Dict[str, np.ndarray] = {}
+    arrays.update(_encode_gridprops_for_npz(spec["gridprops"]))
+    arrays["ncpl"] = np.array(int(spec["ncpl"]), dtype=np.int64)
+    arrays["refine_radius_used"] = np.array(
+        float(spec["refine_radius_used"]), dtype=np.float64
+    )
+
+    for key in _FLOW_SPEC_FLAT_ARRAY_KEYS:
+        arrays[key] = np.asarray(spec[key])
+
+    for key in _FLOW_SPEC_CELLID_KEYS:
+        rows = list(spec[key])
+        arrays[key] = (
+            np.array([[int(r[0]), int(r[1])] for r in rows], dtype=np.int64)
+            if rows
+            else np.zeros((0, 2), dtype=np.int64)
+        )
+
+    for key in _FLOW_SPEC_VALUE_FLOAT_KEYS:
+        arrays[key] = np.asarray(spec[key], dtype=np.float64)
+
+    for key in _FLOW_SPEC_VALUE_INT_KEYS:
+        arrays[key] = np.asarray(spec[key], dtype=np.int64)
+
+    for key in _FLOW_SPEC_OPTIONAL_STR_KEYS:
+        if spec.get(key) is not None:
+            arrays[key] = np.array(str(spec[key]))
+
+    for key in _FLOW_SPEC_OPTIONAL_FLOAT_ARRAY_KEYS:
+        if spec.get(key) is not None:
+            arrays[key] = np.asarray(spec[key], dtype=np.float64)
+
+    return arrays
+
+
+def _decode_flow_spec_from_npz(arrays: Dict[str, np.ndarray]) -> Dict[str, Any]:
+    """Inverse of :func:`_encode_flow_spec_for_npz`."""
+    spec: Dict[str, Any] = {"gridprops": _decode_gridprops_from_npz(arrays)}
+    spec["ncpl"] = int(arrays["ncpl"])
+    spec["refine_radius_used"] = float(arrays["refine_radius_used"])
+
+    for key in _FLOW_SPEC_FLAT_ARRAY_KEYS:
+        spec[key] = arrays[key]
+
+    for key in _FLOW_SPEC_CELLID_KEYS:
+        spec[key] = [tuple(int(x) for x in row) for row in arrays[key]]
+
+    for key in _FLOW_SPEC_VALUE_FLOAT_KEYS + _FLOW_SPEC_VALUE_INT_KEYS:
+        spec[key] = arrays[key]
+
+    for key in _FLOW_SPEC_OPTIONAL_STR_KEYS:
+        spec[key] = str(arrays[key]) if key in arrays else None
+
+    for key in _FLOW_SPEC_OPTIONAL_FLOAT_ARRAY_KEYS:
+        if key in arrays:
+            spec[key] = arrays[key]
+
+    return spec
+
+
+def freeze_flow_spec(
+    spec: Dict[str, Any],
+    npz_path: Union[str, Path],
+    *,
+    caller_fields: Optional[Dict[str, Any]] = None,
+    manifest_path: Optional[Union[str, Path]] = None,
+) -> Dict[str, Any]:
+    """
+    Encode a ``generate_refined_grid`` spec (incl. ragged DISV ``gridprops``)
+    into an NPZ of plain numpy arrays and write a hash-verified manifest for
+    it via :mod:`case_artifact_lock`.
+
+    Parameters
+    ----------
+    spec : dict
+        Grid/property/boundary-condition spec, as returned by
+        :func:`generate_refined_grid` (or hand-built with the same schema).
+    npz_path : str or Path
+        Destination ``.npz`` path. Parent directories are created as needed.
+    caller_fields : dict, optional
+        Free-form fields (e.g. ``{"group": 3, "case": "flow"}``) merged into
+        the manifest JSON alongside the array hashes.
+    manifest_path : str or Path, optional
+        Where to write the manifest. Defaults to a sibling of *npz_path*
+        named ``<npz stem>.manifest.json`` (see
+        ``case_artifact_lock.write_artifact_manifest``).
+
+    Returns
+    -------
+    dict
+        The manifest contents that were written.
+
+    Raises
+    ------
+    KeyError
+        If *spec* is missing a required field.
+    """
+    from case_artifact_lock import write_artifact_manifest
+
+    npz_path = Path(npz_path)
+    arrays = _encode_flow_spec_for_npz(spec)
+
+    npz_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(npz_path, **arrays)
+
+    return write_artifact_manifest(npz_path, caller_fields or {}, manifest_path=manifest_path)
+
+
+def load_flow_spec(
+    npz_path: Union[str, Path],
+    manifest_path: Optional[Union[str, Path]] = None,
+    *,
+    verify: bool = True,
+) -> Dict[str, Any]:
+    """
+    Reconstruct a ``generate_refined_grid`` spec from a frozen ``.npz`` /
+    manifest pair written by :func:`freeze_flow_spec`.
+
+    Reconstruction is pure array decoding -- no Triangle/Voronoi grid
+    generation and no NearestND interpolation are used.
+
+    Parameters
+    ----------
+    npz_path : str or Path
+        Path to the frozen ``.npz`` bundle.
+    manifest_path : str or Path, optional
+        Path to the sibling manifest JSON. Defaults to
+        ``<npz stem>.manifest.json``.
+    verify : bool, optional
+        When True (default), the manifest must exist and every array must
+        hash-match it before decoding (via
+        ``case_artifact_lock.verify_artifact``). When False, the manifest is
+        neither required nor checked.
+
+    Returns
+    -------
+    dict
+        Spec dict with the same schema/shapes as the one passed to
+        :func:`freeze_flow_spec` (``gridprops['cell2d']`` restored with its
+        original ragged row lengths).
+
+    Raises
+    ------
+    FileNotFoundError
+        If *npz_path* does not exist.
+    ValueError
+        If ``verify=True`` and the manifest is missing, malformed, or does
+        not hash-match the ``.npz`` contents.
+    """
+    npz_path = Path(npz_path)
+    if not npz_path.exists():
+        raise FileNotFoundError(f"Frozen flow spec .npz not found: {npz_path}")
+
+    manifest_path = (
+        Path(manifest_path)
+        if manifest_path is not None
+        else npz_path.with_suffix("").with_suffix(".manifest.json")
+    )
+
+    if verify:
+        from case_artifact_lock import verify_artifact
+
+        if not manifest_path.exists():
+            raise ValueError(
+                f"Frozen flow spec manifest not found: {manifest_path}\n"
+                f"Cannot verify {npz_path} (pass verify=False to skip verification)."
+            )
+        verify_artifact(npz_path, manifest_path)
+
+    with np.load(npz_path, allow_pickle=False) as npz:
+        arrays = {name: npz[name] for name in npz.files}
+
+    return _decode_flow_spec_from_npz(arrays)
+
+
+def load_pinned_flow_model(
+    group: Union[int, str],
+    *,
+    meshes_dir: Optional[Union[str, Path]] = None,
+    workspace: Union[str, Path],
+    sim_name: str = "refined_model",
+    verify: bool = True,
+) -> Dict[str, Any]:
+    """
+    Load a per-group pinned flow spec and assemble it into a runnable GWF
+    model -- the graded/student counterpart to :func:`build_refined_gwf_model`
+    that never re-derives grid geometry.
+
+    Resolves ``<meshes_dir>/group<group>_flow.npz`` (+ its sibling manifest),
+    reconstructs the frozen spec via :func:`load_flow_spec`, and assembles it
+    via :func:`assemble_gwf_from_spec`. No Triangle/Voronoi grid generation
+    and no NearestND interpolation are used.
+
+    Parameters
+    ----------
+    group : int or str
+        Student group number/identifier; selects
+        ``group<group>_flow.npz`` within *meshes_dir*.
+    meshes_dir : str or Path, optional
+        Directory containing the instructor-provided ``group<n>_flow.npz`` /
+        ``.manifest.json`` pairs. Defaults to
+        ``<default-data-folder>/pinned_meshes``.
+    workspace : str or Path
+        Directory for the assembled simulation files (see
+        :func:`assemble_gwf_from_spec`).
+    sim_name : str, optional
+        MF6 simulation / model name.
+    verify : bool, optional
+        Passed through to :func:`load_flow_spec`. Default True.
+
+    Returns
+    -------
+    dict
+        Same return shape as :func:`build_refined_gwf_model` /
+        :func:`assemble_gwf_from_spec`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the group's pinned ``.npz`` artifact does not exist.
+    ValueError
+        If ``verify=True`` and the artifact fails manifest verification.
+    """
+    if meshes_dir is None:
+        from data_utils import get_default_data_folder
+
+        meshes_dir = Path(get_default_data_folder()) / "pinned_meshes"
+    else:
+        meshes_dir = Path(meshes_dir)
+
+    npz_path = meshes_dir / f"group{group}_flow.npz"
+    manifest_path = npz_path.with_suffix("").with_suffix(".manifest.json")
+
+    if not npz_path.exists():
+        raise FileNotFoundError(
+            f"Pinned flow spec for group{group} not found: {npz_path}\n"
+            f"Ensure the instructor-provided mesh archive has been extracted "
+            f"into {meshes_dir}."
+        )
+
+    spec = load_flow_spec(npz_path, manifest_path, verify=verify)
     return assemble_gwf_from_spec(spec, workspace=workspace, sim_name=sim_name)
 
 

--- a/_SUPPORT/tests/test_pinned_flow_loader.py
+++ b/_SUPPORT/tests/test_pinned_flow_loader.py
@@ -1,0 +1,504 @@
+"""
+Acceptance tests for milestone M2-pinned-loader.
+
+This milestone adds the PINNED (graded/student) flow loader — the payoff of the
+already-shipped ``generate_refined_grid`` / ``assemble_gwf_from_spec`` split. It
+composes:
+
+  * ``case_artifact_lock`` (write_artifact_manifest / verify_artifact — shipped),
+  * ``assemble_gwf_from_spec`` (shipped in model_io_utils.py),
+
+into three NEW public functions in ``model_io_utils``:
+
+  * ``freeze_flow_spec(spec, npz_path, *, caller_fields=None, manifest_path=None)``
+  * ``load_flow_spec(npz_path, manifest_path=None, *, verify=True)``
+  * ``load_pinned_flow_model(group, *, meshes_dir=None, workspace,
+                             sim_name='refined_model', verify=True)``
+
+so the graded path can rebuild the refined MF6/DISV model from FROZEN numpy
+arrays WITHOUT re-running Triangle/Voronoi (disv_grid_utils) or scipy
+NearestND interpolation.
+
+LOCKED-TEST SCOPING (see milestone brief): these tests MUST NOT run MODFLOW
+(no real ``sim.run_simulation``) and MUST NOT call real Triangle/Voronoi
+refinement or NearestND interpolation. Everything runs off a hand-built tiny
+*ragged* DISV spec; the MF6 solve inside ``assemble_gwf_from_spec`` is stubbed
+so only file writing (never a solve) happens.
+
+Run with:  uv run pytest _SUPPORT/tests/test_pinned_flow_loader.py -v
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Add src to path for imports
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+import model_io_utils as mio  # noqa: E402
+import case_artifact_lock as cal  # noqa: E402
+
+
+# =============================================================================
+# Synthetic tiny *RAGGED* DISV spec.
+#
+# Two cell shapes on purpose (one triangle nv=3, two quads nv=4) so the cell2d
+# encoding genuinely has to survive a ragged round-trip (CSR-style offsets) —
+# a naive rectangular reshape would corrupt it. No Triangle/Voronoi is used:
+# the mesh is hand-built and SIGILL-free.
+#
+#   verts:   3---4---5      (y=10)
+#            |   |   |
+#            0---1---2      (y=0)
+# =============================================================================
+_VERTICES = [
+    [0, 0.0, 0.0], [1, 10.0, 0.0], [2, 20.0, 0.0],
+    [3, 0.0, 10.0], [4, 10.0, 10.0], [5, 20.0, 10.0],
+]
+_CELL2D = [
+    [0, 3.0, 6.0, 3, 3, 0, 4],       # triangle  (nv=3) -> row length 7
+    [1, 5.0, 5.0, 4, 0, 1, 4, 3],    # quad       (nv=4) -> row length 8
+    [2, 15.0, 5.0, 4, 1, 2, 5, 4],   # quad       (nv=4) -> row length 8
+]
+_NCPL = 3
+_NVERT = 6
+
+FLAT_KEYS = [
+    "top", "botm", "k", "rch", "strt", "idomain",
+    "chd_cellid", "chd_head",
+    "riv_cellid", "riv_stage", "riv_cond", "riv_rbot",
+    "wel_cellid", "wel_rate", "well_cells",
+]
+
+RESULT_KEYS = ("sim", "gwf", "modelgrid", "gridprops", "ncpl", "heads", "well_cells")
+
+
+def _gridprops():
+    return {
+        "nvert": _NVERT,
+        "vertices": [list(v) for v in _VERTICES],
+        "cell2d": [list(c) for c in _CELL2D],
+        "ncpl": _NCPL,
+    }
+
+
+def _synthetic_spec(with_wells=True):
+    spec = {
+        "gridprops": _gridprops(),
+        "ncpl": _NCPL,
+        "top": np.array([10.0, 10.0, 10.0]),
+        "botm": np.array([0.0, 0.0, 0.0]),
+        "k": np.array([7.5, 3.25, 12.0]),
+        "rch": np.array([1e-4, 1e-4, 1e-4]),
+        "strt": np.array([8.0, 8.5, 9.0]),
+        "idomain": np.ones(_NCPL, dtype=int),
+        "chd_cellid": [(0, 0), (0, 2)],
+        "chd_head": [8.0, 9.0],
+        "riv_cellid": [(0, 1)],
+        "riv_stage": [7.5],
+        "riv_cond": [50.0],
+        "riv_rbot": [6.0],
+        "refine_radius_used": 175.0,
+        "crs": "EPSG:2056",
+    }
+    if with_wells:
+        spec["wel_cellid"] = [(0, 1)]
+        spec["wel_rate"] = [-30.0]
+        spec["well_cells"] = [1]
+    else:
+        spec["wel_cellid"] = []
+        spec["wel_rate"] = []
+        spec["well_cells"] = []
+    return spec
+
+
+# =============================================================================
+# Solve stub: intercept MODFLOW so assemble writes (no run) and returns heads.
+# =============================================================================
+def _stub_solve(monkeypatch):
+    import flopy
+
+    state = {"ran": False}
+
+    def fake_run(self, *a, **k):
+        state["ran"] = True
+        return True, []
+
+    class _FakeHead:
+        def get_data(self):
+            return np.full((1, 1, _NCPL), 8.5)
+
+    class _FakeOutput:
+        def head(self, *a, **k):
+            return _FakeHead()
+
+    monkeypatch.setattr(flopy.mf6.MFSimulation, "run_simulation", fake_run)
+    monkeypatch.setattr(
+        flopy.mf6.ModflowGwf, "output",
+        property(lambda self: _FakeOutput()), raising=False,
+    )
+    return state
+
+
+def _patch_regeneration_to_raise(monkeypatch):
+    """Trip-wire every geometry-regeneration entry point.
+
+    If the graded path touches Triangle/Voronoi or NearestND, it explodes —
+    proving the pinned loader rebuilds purely from frozen arrays.
+    """
+    import disv_grid_utils as dgu
+    import scipy.interpolate as si
+
+    def boom(*a, **k):
+        raise AssertionError(
+            "graded/pinned path must NOT regenerate geometry "
+            "(Triangle/Voronoi/NearestND called)"
+        )
+
+    monkeypatch.setattr(dgu, "create_disv_from_boundary", boom)
+    monkeypatch.setattr(dgu, "refine_grid_locally", boom)
+    monkeypatch.setattr(si, "NearestNDInterpolator", boom)
+    # Belt-and-suspenders if the symbol was imported into mio's namespace.
+    monkeypatch.setattr(mio, "NearestNDInterpolator", boom, raising=False)
+
+
+def _tamper_npz_content(npz_path):
+    """Rewrite the .npz so one member's CONTENT changes while member names and
+    the (now stale) manifest are left intact -> hash mismatch."""
+    with np.load(npz_path, allow_pickle=False) as z:
+        members = {name: z[name] for name in z.files}
+    key = next(k for k in members if members[k].size > 0)
+    perturbed = np.array(members[key])
+    perturbed.reshape(-1)[0] = perturbed.reshape(-1)[0] + 1
+    members[key] = perturbed
+    np.savez(npz_path, **members)
+
+
+def _drop_npz_member(npz_path):
+    """Rewrite the .npz missing one member the manifest still records."""
+    with np.load(npz_path, allow_pickle=False) as z:
+        names = list(z.files)
+        members = {name: z[name] for name in names[:-1]}
+    np.savez(npz_path, **members)
+
+
+# =============================================================================
+# Round-trip equivalence helpers
+# =============================================================================
+def _assert_flat_arrays_equal(loaded, original):
+    for k in FLAT_KEYS:
+        a = np.asarray(loaded[k])
+        b = np.asarray(original[k])
+        assert a.shape == b.shape, f"spec['{k}'] shape {a.shape} != {b.shape}"
+        assert np.array_equal(a, b), f"spec['{k}'] content changed on round-trip"
+
+
+def _rows_as_floats(rows):
+    return [[float(x) for x in row] for row in rows]
+
+
+def _assert_gridprops_equivalent(loaded_gp, orig_gp):
+    assert int(loaded_gp["nvert"]) == int(orig_gp["nvert"])
+    assert int(loaded_gp["ncpl"]) == int(orig_gp["ncpl"])
+    # vertices: rectangular (nvert, 3)
+    assert _rows_as_floats(loaded_gp["vertices"]) == _rows_as_floats(orig_gp["vertices"])
+    # cell2d: RAGGED — row lengths differ (7 for the triangle, 8 for the quads);
+    # comparing row-by-row proves the offsets survived, not just the payload.
+    lc = _rows_as_floats(loaded_gp["cell2d"])
+    oc = _rows_as_floats(orig_gp["cell2d"])
+    assert [len(r) for r in lc] == [len(r) for r in oc], "cell2d raggedness lost"
+    assert lc == oc, "cell2d contents changed on round-trip"
+    # structural sanity: sizes line up with the counts
+    assert len(loaded_gp["cell2d"]) == int(loaded_gp["ncpl"])
+    assert len(loaded_gp["vertices"]) == int(loaded_gp["nvert"])
+
+
+def _build_disv_from_gridprops(tmp_path, gp, spec):
+    """Rebuild a real (never-run) flopy DISV from the reconstructed gridprops
+    to prove it is a consumable, equivalent grid. No MODFLOW solve."""
+    import flopy
+
+    sim = flopy.mf6.MFSimulation(sim_name="rt", sim_ws=str(tmp_path / "rt"))
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1)])
+    flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="rt")
+    disv = flopy.mf6.ModflowGwfdisv(
+        gwf, nlay=1, ncpl=int(gp["ncpl"]), nvert=int(gp["nvert"]),
+        top=np.asarray(spec["top"], dtype=float),
+        botm=[np.asarray(spec["botm"], dtype=float)],
+        vertices=gp["vertices"], cell2d=gp["cell2d"],
+        idomain=[np.ones(int(gp["ncpl"]), dtype=int)],
+    )
+    return disv
+
+
+# =============================================================================
+# API presence
+# =============================================================================
+class TestPinnedLoaderApiExists:
+    @pytest.mark.parametrize("name", ["freeze_flow_spec", "load_flow_spec",
+                                      "load_pinned_flow_model"])
+    def test_function_exists(self, name):
+        assert hasattr(mio, name) and callable(getattr(mio, name)), (
+            f"model_io_utils.{name} must exist"
+        )
+
+
+# =============================================================================
+# Criterion 1: freeze_flow_spec
+# =============================================================================
+class TestFreezeFlowSpec:
+
+    def test_writes_npz_and_manifest_creating_parent_dirs(self, tmp_path):
+        npz = tmp_path / "nested" / "deep" / "group3_flow.npz"
+        mio.freeze_flow_spec(_synthetic_spec(), npz)
+        manifest = npz.with_suffix("").with_suffix(".manifest.json")
+        assert npz.exists(), "freeze must create the .npz (incl. parent dirs)"
+        assert manifest.exists(), "freeze must write the sibling manifest"
+
+    def test_manifest_verifies_against_npz(self, tmp_path):
+        # Proves freeze went through case_artifact_lock.write_artifact_manifest:
+        # verify_artifact must accept the pair it produced.
+        npz = tmp_path / "group3_flow.npz"
+        mio.freeze_flow_spec(_synthetic_spec(), npz)
+        manifest = npz.with_suffix("").with_suffix(".manifest.json")
+        assert cal.verify_artifact(npz, manifest) is True
+
+    def test_npz_members_are_plain_numpy_no_pickle(self, tmp_path):
+        # "an .npz of numpy arrays" — ragged gridprops must be encoded to FLAT
+        # numeric arrays, NOT stashed as pickled python objects. Loading with
+        # the numpy default (allow_pickle=False) must succeed for every member.
+        npz = tmp_path / "group3_flow.npz"
+        mio.freeze_flow_spec(_synthetic_spec(), npz)
+        with np.load(npz, allow_pickle=False) as z:
+            assert len(z.files) >= 1
+            for name in z.files:
+                arr = z[name]  # raises if this member was pickled
+                assert isinstance(arr, np.ndarray)
+                assert arr.dtype != object, f"member {name!r} is an object array"
+
+    def test_caller_fields_flow_into_manifest(self, tmp_path):
+        npz = tmp_path / "group3_flow.npz"
+        mio.freeze_flow_spec(
+            _synthetic_spec(), npz, caller_fields={"group": 3, "case": "flow"}
+        )
+        manifest = json.loads(
+            npz.with_suffix("").with_suffix(".manifest.json").read_text()
+        )
+        assert manifest.get("group") == 3
+        assert manifest.get("case") == "flow"
+
+    def test_explicit_manifest_path_is_honored(self, tmp_path):
+        npz = tmp_path / "group3_flow.npz"
+        manifest = tmp_path / "elsewhere" / "custom.manifest.json"
+        mio.freeze_flow_spec(_synthetic_spec(), npz, manifest_path=manifest)
+        assert manifest.exists()
+        assert cal.verify_artifact(npz, manifest) is True
+
+
+# =============================================================================
+# Criterion 2 + 4: load_flow_spec round-trips the spec and rebuilds the DISV.
+# =============================================================================
+class TestLoadFlowSpecRoundTrip:
+
+    def _freeze(self, tmp_path, spec=None):
+        spec = spec if spec is not None else _synthetic_spec()
+        npz = tmp_path / "group3_flow.npz"
+        mio.freeze_flow_spec(spec, npz)
+        return spec, npz
+
+    def test_flat_arrays_round_trip_exactly(self, tmp_path):
+        orig, npz = self._freeze(tmp_path)
+        loaded = mio.load_flow_spec(npz)
+        _assert_flat_arrays_equal(loaded, orig)
+
+    def test_refine_radius_used_round_trips(self, tmp_path):
+        orig, npz = self._freeze(tmp_path)
+        loaded = mio.load_flow_spec(npz)
+        assert float(np.asarray(loaded["refine_radius_used"])) == pytest.approx(
+            float(orig["refine_radius_used"])
+        )
+
+    def test_gridprops_round_trip_ragged(self, tmp_path):
+        orig, npz = self._freeze(tmp_path)
+        loaded = mio.load_flow_spec(npz)
+        _assert_gridprops_equivalent(loaded["gridprops"], orig["gridprops"])
+
+    def test_reconstructed_gridprops_rebuild_equivalent_disv(self, tmp_path):
+        # Criterion 4: reconstructed gridprops must rebuild an equivalent flopy
+        # DISV (same nlay/ncpl/nvert + identical vertices/cell2d). No solve.
+        orig, npz = self._freeze(tmp_path)
+        loaded = mio.load_flow_spec(npz)
+        disv = _build_disv_from_gridprops(tmp_path, loaded["gridprops"], loaded)
+        assert int(np.asarray(disv.ncpl.get_data())) == _NCPL
+        assert int(np.asarray(disv.nvert.get_data())) == _NVERT
+
+    def test_empty_wells_round_trip_present_but_empty(self, tmp_path):
+        # Negative/edge path: a well-free spec must round-trip the WEL keys as
+        # present-but-empty (not dropped, not defaulted to a bogus record).
+        orig, npz = self._freeze(tmp_path, _synthetic_spec(with_wells=False))
+        loaded = mio.load_flow_spec(npz)
+        for key in ("wel_cellid", "wel_rate", "well_cells"):
+            assert key in loaded
+            assert len(np.asarray(loaded[key]).reshape(-1)) == 0
+
+    def test_load_does_not_regenerate_geometry(self, tmp_path, monkeypatch):
+        # load_flow_spec must reconstruct without Triangle/Voronoi/NearestND.
+        orig, npz = self._freeze(tmp_path)
+        _patch_regeneration_to_raise(monkeypatch)
+        loaded = mio.load_flow_spec(npz)
+        _assert_gridprops_equivalent(loaded["gridprops"], orig["gridprops"])
+
+    def test_source_has_no_refinement_or_interpolation(self):
+        src = inspect.getsource(mio.load_flow_spec)
+        for forbidden in ("disv_grid_utils", "create_disv_from_boundary",
+                          "refine_grid_locally", "NearestNDInterpolator"):
+            assert forbidden not in src, (
+                f"load_flow_spec must not reference {forbidden!r}"
+            )
+
+
+# =============================================================================
+# Criterion 2 (error paths): verification is FIRST and gated by verify=.
+# =============================================================================
+class TestLoadFlowSpecVerification:
+
+    def _freeze(self, tmp_path):
+        npz = tmp_path / "group3_flow.npz"
+        mio.freeze_flow_spec(_synthetic_spec(), npz)
+        return npz
+
+    def test_tampered_content_raises_valueerror(self, tmp_path):
+        npz = self._freeze(tmp_path)
+        _tamper_npz_content(npz)
+        with pytest.raises(ValueError):
+            mio.load_flow_spec(npz)  # verify=True default
+
+    def test_missing_member_raises_valueerror(self, tmp_path):
+        npz = self._freeze(tmp_path)
+        _drop_npz_member(npz)
+        with pytest.raises(ValueError):
+            mio.load_flow_spec(npz)
+
+    def test_missing_manifest_raises_when_verify_true(self, tmp_path):
+        npz = self._freeze(tmp_path)
+        npz.with_suffix("").with_suffix(".manifest.json").unlink()
+        with pytest.raises(ValueError):
+            mio.load_flow_spec(npz, verify=True)
+
+    def test_verify_false_skips_verification(self, tmp_path):
+        # verify=False must reconstruct WITHOUT requiring/validating the
+        # manifest — proving verification is genuinely gated by the flag and
+        # verify=True is not a no-op that always passes.
+        orig = _synthetic_spec()
+        npz = tmp_path / "group3_flow.npz"
+        mio.freeze_flow_spec(orig, npz)
+        npz.with_suffix("").with_suffix(".manifest.json").unlink()
+        loaded = mio.load_flow_spec(npz, verify=False)
+        _assert_flat_arrays_equal(loaded, orig)
+
+
+# =============================================================================
+# Criterion 3 + 5: load_pinned_flow_model
+# =============================================================================
+class TestLoadPinnedFlowModel:
+
+    GROUP = 3
+
+    def _freeze_group(self, meshes_dir, group=None, spec=None):
+        group = self.GROUP if group is None else group
+        spec = spec if spec is not None else _synthetic_spec()
+        meshes_dir.mkdir(parents=True, exist_ok=True)
+        npz = meshes_dir / f"group{group}_flow.npz"
+        mio.freeze_flow_spec(spec, npz)
+        return npz
+
+    def test_returns_build_refined_result_keys(self, tmp_path, monkeypatch):
+        meshes = tmp_path / "meshes"
+        self._freeze_group(meshes)
+        _stub_solve(monkeypatch)
+        result = mio.load_pinned_flow_model(
+            self.GROUP, meshes_dir=meshes, workspace=str(tmp_path / "ws"),
+        )
+        for key in RESULT_KEYS:
+            assert key in result, f"load_pinned_flow_model result missing {key!r}"
+        assert int(result["ncpl"]) == _NCPL
+        assert list(result["well_cells"]) == [1]
+
+    def test_no_regeneration_contract(self, tmp_path, monkeypatch):
+        # Criterion 5: with all geometry regeneration trip-wired to RAISE and
+        # the solve stubbed, the pinned loader still returns a runnable model —
+        # proving the graded path never re-derives geometry.
+        meshes = tmp_path / "meshes"
+        self._freeze_group(meshes)
+        _stub_solve(monkeypatch)
+        _patch_regeneration_to_raise(monkeypatch)
+        result = mio.load_pinned_flow_model(
+            self.GROUP, meshes_dir=meshes, workspace=str(tmp_path / "ws"),
+        )
+        for key in RESULT_KEYS:
+            assert key in result
+
+    def test_resolves_group_artifact_by_name(self, tmp_path, monkeypatch):
+        # Only group7's artifact exists; requesting group7 must resolve
+        # <meshes_dir>/group7_flow.npz (+ sibling manifest).
+        meshes = tmp_path / "meshes"
+        self._freeze_group(meshes, group=7)
+        _stub_solve(monkeypatch)
+        result = mio.load_pinned_flow_model(
+            7, meshes_dir=meshes, workspace=str(tmp_path / "ws7"),
+        )
+        assert int(result["ncpl"]) == _NCPL
+
+    def test_missing_artifact_raises_actionable_error(self, tmp_path, monkeypatch):
+        meshes = tmp_path / "meshes"
+        meshes.mkdir(parents=True, exist_ok=True)  # exists but empty
+        _stub_solve(monkeypatch)
+        with pytest.raises((FileNotFoundError, ValueError)) as exc:
+            mio.load_pinned_flow_model(
+                self.GROUP, meshes_dir=meshes, workspace=str(tmp_path / "ws"),
+            )
+        msg = str(exc.value).lower()
+        assert (f"group{self.GROUP}" in msg or ".npz" in msg
+                or "manifest" in msg or "not found" in msg or "missing" in msg), (
+            f"error message not actionable: {exc.value!r}"
+        )
+
+    def test_hash_mismatch_propagates_valueerror(self, tmp_path, monkeypatch):
+        meshes = tmp_path / "meshes"
+        npz = self._freeze_group(meshes)
+        _tamper_npz_content(npz)
+        _stub_solve(monkeypatch)
+        with pytest.raises(ValueError):
+            mio.load_pinned_flow_model(
+                self.GROUP, meshes_dir=meshes, workspace=str(tmp_path / "ws"),
+                verify=True,
+            )
+
+    def test_sim_name_is_used(self, tmp_path, monkeypatch):
+        meshes = tmp_path / "meshes"
+        self._freeze_group(meshes)
+        _stub_solve(monkeypatch)
+        ws = tmp_path / "ws"
+        mio.load_pinned_flow_model(
+            self.GROUP, meshes_dir=meshes, workspace=str(ws),
+            sim_name="my_pinned",
+        )
+        # assemble writes <sim_name>.nam / <sim_name>.disv into the workspace.
+        written = {p.name for p in ws.glob("*")}
+        assert "my_pinned.nam" in written and "my_pinned.disv" in written
+
+    def test_source_has_no_refinement_or_interpolation(self):
+        src = inspect.getsource(mio.load_pinned_flow_model)
+        for forbidden in ("disv_grid_utils", "create_disv_from_boundary",
+                          "refine_grid_locally", "NearestNDInterpolator"):
+            assert forbidden not in src, (
+                f"load_pinned_flow_model must not reference {forbidden!r}"
+            )


### PR DESCRIPTION
## Gate
Pinned loader enables grading workflow: encode refined-grid spec to NPZ + hash-verified manifest; load+assemble model without re-running Triangle/Voronoi geometry or scipy NearestND interpolation.

## Conformance
- [x] Locked acceptance tests pass
- [x] Codec round-trips all flow spec keys (gridprops, BC cellids/values, well assignments, baseline heads)
- [x] DISV ragged cell2d geometry preserved losslessly via CSR-style (flat + lengths)
- [x] Integrates existing case_artifact_lock (manifest write/verify) + assemble_gwf_from_spec (pure MF6 construction)
- [x] No Triangle/scipy calls on load path
- [x] Per-group application workflow (NB8) can pin spec at freeze time + rebuild from manifest