### PR TITLE
Promote _refine_with_retry to public model_io_utils.refine_with_retry

### DIFF
--- a/_SUPPORT/src/model_io_utils.py
+++ b/_SUPPORT/src/model_io_utils.py
@@ -21,6 +21,7 @@ Functions:
     load_base_simulation: Load pre-built MF6 simulation
     compare_water_balances: Compare two water balance DataFrames
     build_refined_gwf_model: Build locally-refined GWF model from coarse model
+    refine_with_retry: Retry build_refined_gwf_model over a set of refine radii
     build_prt_model: Build PRT particle-tracking simulation from GWF model
     load_prt_results: Load and classify PRT tracking results
     freeze_flow_spec: Encode a refined-grid spec (incl. ragged DISV gridprops)
@@ -38,7 +39,7 @@ import os
 import json
 import zipfile
 from pathlib import Path
-from typing import Union, Dict, List, Optional, Any
+from typing import Union, Dict, List, Optional, Any, Tuple, Sequence
 
 import numpy as np
 import pandas as pd
@@ -2419,6 +2420,63 @@ def build_refined_gwf_model(
         baseline_head_array=baseline_head_array,
     )
     return assemble_gwf_from_spec(spec, workspace=workspace, sim_name=sim_name)
+
+
+def refine_with_retry(
+    coarse_gwf,
+    boundary_gdf: gpd.GeoDataFrame,
+    river_gdf: gpd.GeoDataFrame,
+    refine_points: Union[List[tuple], gpd.GeoDataFrame],
+    head_array: np.ndarray,
+    workspace: Union[str, Path],
+    *,
+    refine_radii: Sequence[float] = (70.0, 62.0, 78.0, 56.0, 84.0),
+    base_cell_size: float = 50.0,
+    refined_cell_size: float = 10.0,
+    sim_name: str = "rg",
+) -> Tuple[Dict[str, Any], float]:
+    """Refine the corridor via :func:`build_refined_gwf_model`, retrying over a
+    small set of refine radii.
+
+    cs=10 local refinement SIGILL-crashes on a fraction of source locations
+    (macOS arm64 / mf6 6.7.0) and boundary-clipped circles can trip a Triangle
+    precision abort.  Both manifest as an exception out of
+    ``build_refined_gwf_model``.  Walking the radius slightly
+    (70 -> 62 -> 78 -> 56 -> 84 m) reliably dodges the crash for the validated
+    student doublets (the corridor stays well-resolved at any of these radii:
+    Pe_L <= 2 throughout).
+
+    Each radius attempt gets its own ``workspace/rg<k>`` subworkspace so a
+    failed attempt's partial files never collide with the next retry.
+
+    Returns
+    -------
+    (result_dict, radius_used)
+        ``result_dict`` is the ``build_refined_gwf_model`` return value for
+        the radius that succeeded; ``radius_used`` is that radius (float).
+
+    Raises
+    ------
+    RuntimeError
+        If every radius in *refine_radii* fails.
+    """
+    workspace = Path(workspace)
+    last_exc: Optional[Exception] = None
+    for k, rr in enumerate(refine_radii):
+        try:
+            res = build_refined_gwf_model(
+                coarse_gwf, boundary_gdf=boundary_gdf, river_gdf=river_gdf,
+                refine_points=refine_points, head_array=head_array,
+                workspace=str(workspace / f"rg{k}"), refine_radius=float(rr),
+                base_cell_size=base_cell_size, refined_cell_size=refined_cell_size,
+                sim_name=sim_name)
+            return res, float(rr)
+        except Exception as e:  # SIGILL / Triangle abort surface here
+            last_exc = e
+            continue
+    raise RuntimeError(
+        f"corridor refinement failed at all radii {tuple(refine_radii)}; "
+        f"last error: {last_exc!r}")
 
 
 # =============================================================================

--- a/_SUPPORT/src/transport_base_model.py
+++ b/_SUPPORT/src/transport_base_model.py
@@ -138,39 +138,9 @@ def _corridor_points(a_xy, b_xy, step: float = 40.0, pad: float = 40.0):
     return [tuple(a + s * u) for s in np.linspace(-pad, L + pad, n)], u, L
 
 
-def _refine_with_retry(coarse_gwf, boundary_gdf, river_gdf, refine_points, head_array,
-                       workspace: Union[str, Path], *,
-                       refine_radii: Sequence[float] = (70.0, 62.0, 78.0, 56.0, 84.0),
-                       base_cell_size: float = 50.0, refined_cell_size: float = 10.0,
-                       sim_name: str = "rg") -> Tuple[Dict[str, Any], float]:
-    """Refine the corridor, retrying over a small set of refine radii.
-
-    cs=10 local refinement SIGILL-crashes on a fraction of source locations
-    (macOS arm64 / mf6 6.7.0) and boundary-clipped circles can trip a Triangle
-    precision abort.  Both manifest as an exception out of build_refined_gwf_model.
-    Walking the radius slightly (70 -> 62 -> 78 -> 56 -> 84 m) reliably dodges the
-    crash for the validated student doublets (the corridor stays well-resolved at
-    any of these radii: Pe_L <= 2 throughout).
-
-    Returns (build_refined_gwf_model result dict, radius actually used).
-    """
-    workspace = Path(workspace)
-    last_exc: Optional[Exception] = None
-    for k, rr in enumerate(refine_radii):
-        try:
-            res = mio.build_refined_gwf_model(
-                coarse_gwf, boundary_gdf=boundary_gdf, river_gdf=river_gdf,
-                refine_points=refine_points, head_array=head_array,
-                workspace=str(workspace / f"rg{k}"), refine_radius=float(rr),
-                base_cell_size=base_cell_size, refined_cell_size=refined_cell_size,
-                sim_name=sim_name)
-            return res, float(rr)
-        except Exception as e:  # SIGILL / Triangle abort surface here
-            last_exc = e
-            continue
-    raise RuntimeError(
-        f"corridor refinement failed at all radii {tuple(refine_radii)}; "
-        f"last error: {last_exc!r}")
+# Promoted to model_io_utils.refine_with_retry (public, reusable outside transport);
+# kept as a thin local alias so existing callers in this module are unchanged.
+_refine_with_retry = mio.refine_with_retry
 
 
 def courant_nstp(v_cells: np.ndarray, size_cells: np.ndarray, mask: np.ndarray,

--- a/_SUPPORT/tests/test_refine_with_retry.py
+++ b/_SUPPORT/tests/test_refine_with_retry.py
@@ -1,0 +1,280 @@
+"""
+Acceptance tests for milestone M2-refine-retry.
+
+Promote the transport-only ``_refine_with_retry`` (radius-walk mitigation for the
+cs=10 SIGILL / Triangle-precision aborts) into a PUBLIC helper
+``model_io_utils.refine_with_retry`` so the flow path can reuse it, and re-export
+it from ``transport_base_model`` so ``build_spill_scenario`` / ``build_doublet_base``
+call the SAME logic unchanged.
+
+LOCKED-TEST SCOPING (do not weaken): these tests NEVER run MODFLOW or a real
+Triangle/Voronoi refinement.  ``model_io_utils.build_refined_gwf_model`` is
+monkeypatched with fakes that either raise or return a sentinel dict, so the only
+thing exercised is the retry / subworkspace / return / raise control flow.
+
+Run with:  uv run pytest _SUPPORT/tests/test_refine_with_retry.py -v
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add src to path for imports (same pattern as the other tests in this dir).
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import model_io_utils as mio  # noqa: E402
+import transport_base_model as tbm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fake build_refined_gwf_model
+# ---------------------------------------------------------------------------
+# Mirrors the REAL build_refined_gwf_model signature so calls bind whether the
+# caller passes args positionally or by keyword.  ``behavior(call_index,
+# refine_radius)`` decides the outcome per radius: return an Exception INSTANCE
+# to have the fake raise it, or any other object to have the fake return it.
+def _make_fake(behavior):
+    calls = []
+
+    def fake(gwf, boundary_gdf=None, river_gdf=None, refine_points=None,
+             head_array=None, workspace=None, refine_radius=200.0,
+             base_cell_size=50.0, refined_cell_size=10.0, well_data=None,
+             sim_name="refined_model", baseline_head_array=None):
+        calls.append(dict(
+            gwf=gwf, boundary_gdf=boundary_gdf, river_gdf=river_gdf,
+            refine_points=refine_points, head_array=head_array,
+            workspace=workspace, refine_radius=refine_radius,
+            base_cell_size=base_cell_size, refined_cell_size=refined_cell_size,
+            sim_name=sim_name,
+        ))
+        outcome = behavior(len(calls) - 1, refine_radius)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    fake.calls = calls
+    return fake
+
+
+# Opaque sentinels — the helper must forward these through untouched, so the
+# tests do not depend on any real model object.
+COARSE = object()
+BOUNDARY = object()
+RIVER = object()
+POINTS = [(0.0, 0.0), (100.0, 0.0)]
+HEADS = object()
+
+DEFAULT_RADII = (70.0, 62.0, 78.0, 56.0, 84.0)
+
+
+def _basenames(fake):
+    return [os.path.basename(str(c["workspace"])) for c in fake.calls]
+
+
+# ===========================================================================
+# Criterion 1 — model_io_utils.refine_with_retry is a PUBLIC helper with the
+# specified signature and radius-walk behavior.
+# ===========================================================================
+def test_refine_with_retry_is_public():
+    assert hasattr(mio, "refine_with_retry"), (
+        "model_io_utils must define a PUBLIC refine_with_retry helper"
+    )
+    fn = mio.refine_with_retry
+    assert callable(fn)
+    assert not fn.__name__.startswith("_"), "helper must be public (no leading _)"
+
+
+def test_refine_with_retry_signature_and_defaults():
+    sig = inspect.signature(mio.refine_with_retry)
+    params = sig.parameters
+
+    # Six leading (positional) inputs, in order.
+    leading = ["coarse_gwf", "boundary_gdf", "river_gdf",
+               "refine_points", "head_array", "workspace"]
+    assert list(params)[:6] == leading
+
+    # The tuning knobs are KEYWORD-ONLY (the `*` in the spec) with locked defaults.
+    for name, expected in [
+        ("refine_radii", DEFAULT_RADII),
+        ("base_cell_size", 50.0),
+        ("refined_cell_size", 10.0),
+        ("sim_name", "rg"),
+    ]:
+        assert name in params, f"missing keyword-only parameter {name!r}"
+        p = params[name]
+        assert p.kind is inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} must be keyword-only"
+        )
+    # exact default values
+    assert tuple(params["refine_radii"].default) == DEFAULT_RADII
+    assert params["base_cell_size"].default == 50.0
+    assert params["refined_cell_size"].default == 10.0
+    assert params["sim_name"].default == "rg"
+
+
+def test_first_radius_success_returns_dict_and_radius(monkeypatch):
+    sentinel = {"gwf": "SENTINEL"}
+    fake = _make_fake(lambda i, rr: sentinel)  # always succeeds
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    res, radius = mio.refine_with_retry(
+        COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws")
+
+    # Returns (result_dict, radius_used) with the FIRST radius, first try only.
+    assert res is sentinel
+    assert radius == 70.0
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["refine_radius"] == 70.0
+    # per-radius subworkspace workspace/rg<k>
+    assert _basenames(fake) == ["rg0"]
+
+
+def test_forwards_all_inputs_to_build(monkeypatch):
+    sentinel = object()
+    fake = _make_fake(lambda i, rr: sentinel)
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    mio.refine_with_retry(
+        COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws",
+        base_cell_size=33.0, refined_cell_size=7.0, sim_name="zz")
+
+    c = fake.calls[0]
+    assert c["gwf"] is COARSE
+    assert c["boundary_gdf"] is BOUNDARY
+    assert c["river_gdf"] is RIVER
+    assert c["refine_points"] is POINTS
+    assert c["head_array"] is HEADS
+    assert c["base_cell_size"] == 33.0
+    assert c["refined_cell_size"] == 7.0
+    assert c["sim_name"] == "zz"
+
+
+def test_walks_radii_in_order_until_first_success(monkeypatch):
+    sentinel = object()
+
+    # Fail on the first two radii, succeed on the third (78.0).
+    def behavior(i, rr):
+        if i < 2:
+            return RuntimeError(f"SIGILL at radius {rr}")
+        return sentinel
+
+    fake = _make_fake(behavior)
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    res, radius = mio.refine_with_retry(
+        COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws")
+
+    assert res is sentinel
+    assert radius == 78.0
+    # exactly three attempts, in default order, no attempt past the first success
+    assert [c["refine_radius"] for c in fake.calls] == [70.0, 62.0, 78.0]
+    assert _basenames(fake) == ["rg0", "rg1", "rg2"]
+
+
+def test_custom_refine_radii_honored(monkeypatch):
+    sentinel = object()
+
+    def behavior(i, rr):
+        return sentinel if rr == 22.0 else RuntimeError("nope")
+
+    fake = _make_fake(behavior)
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    res, radius = mio.refine_with_retry(
+        COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws",
+        refine_radii=(11.0, 22.0, 33.0))
+
+    assert res is sentinel
+    assert radius == 22.0
+    assert [c["refine_radius"] for c in fake.calls] == [11.0, 22.0]
+    assert _basenames(fake) == ["rg0", "rg1"]
+
+
+def test_all_radii_fail_raises_runtimeerror_naming_radii_and_last_error(monkeypatch):
+    def behavior(i, rr):
+        # distinct messages; the LAST one must surface in the RuntimeError.
+        return ValueError("boom-last" if rr == 33.0 else f"boom-{rr}")
+
+    fake = _make_fake(behavior)
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    with pytest.raises(RuntimeError) as exc:
+        mio.refine_with_retry(
+            COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws",
+            refine_radii=(11.0, 22.0, 33.0))
+
+    msg = str(exc.value)
+    # names every tried radius ...
+    for rr in ("11.0", "22.0", "33.0"):
+        assert rr in msg, f"RuntimeError message must name tried radius {rr}"
+    # ... and the last underlying error.
+    assert "boom-last" in msg
+    # every radius was attempted
+    assert [c["refine_radius"] for c in fake.calls] == [11.0, 22.0, 33.0]
+
+
+def test_underlying_exception_not_leaked_on_total_failure(monkeypatch):
+    # A single-radius total failure must still raise RuntimeError, not the
+    # raw KeyError from build_refined_gwf_model.
+    fake = _make_fake(lambda i, rr: KeyError("raw"))
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    with pytest.raises(RuntimeError):
+        mio.refine_with_retry(
+            COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws",
+            refine_radii=(70.0,))
+
+
+# ===========================================================================
+# Criterion 2 — transport_base_model re-exports the promoted helper as the
+# module attribute _refine_with_retry, so build_spill_scenario /
+# build_doublet_base call the SAME logic.  We assert behavioral equivalence
+# (accepts either `_refine_with_retry = mio.refine_with_retry` or a thin
+# wrapper) — never a divergent private copy.
+# ===========================================================================
+def test_transport_reexports_helper_attribute():
+    assert hasattr(tbm, "_refine_with_retry"), (
+        "transport_base_model must keep a module attribute _refine_with_retry "
+        "(the promoted helper) for build_spill_scenario/build_doublet_base"
+    )
+    assert callable(tbm._refine_with_retry)
+
+
+@pytest.mark.parametrize("caller_name", ["refine_with_retry", "_refine_with_retry"])
+def test_promoted_and_transport_helpers_share_behavior(monkeypatch, caller_name):
+    # Same fake scenario driven through BOTH the public mio helper and the
+    # transport re-export must yield identical control flow.
+    caller = (mio.refine_with_retry if caller_name == "refine_with_retry"
+              else tbm._refine_with_retry)
+
+    sentinel = object()
+
+    def behavior(i, rr):
+        # succeed on the 2nd radius (62.0)
+        return sentinel if i == 1 else RuntimeError("retry")
+
+    fake = _make_fake(behavior)
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    res, radius = caller(COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws")
+
+    assert res is sentinel
+    assert radius == 62.0
+    assert [c["refine_radius"] for c in fake.calls] == [70.0, 62.0]
+    assert _basenames(fake) == ["rg0", "rg1"]
+
+
+def test_transport_helper_total_failure_matches(monkeypatch):
+    # The transport re-export must also raise RuntimeError on total failure.
+    fake = _make_fake(lambda i, rr: ValueError("still-boom"))
+    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
+
+    with pytest.raises(RuntimeError) as exc:
+        tbm._refine_with_retry(
+            COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws",
+            refine_radii=(70.0, 62.0))
+    assert "still-boom" in str(exc.value)

--- a/_SUPPORT/tests/test_refine_with_retry.py
+++ b/_SUPPORT/tests/test_refine_with_retry.py
@@ -230,51 +230,69 @@ def test_underlying_exception_not_leaked_on_total_failure(monkeypatch):
 
 
 # ===========================================================================
-# Criterion 2 — transport_base_model re-exports the promoted helper as the
-# module attribute _refine_with_retry, so build_spill_scenario /
-# build_doublet_base call the SAME logic.  We assert behavioral equivalence
-# (accepts either `_refine_with_retry = mio.refine_with_retry` or a thin
-# wrapper) — never a divergent private copy.
+# Criterion 2 — transport_base_model NO LONGER defines its own copy of the
+# retry body.  It re-exports the promoted helper as the module attribute
+# _refine_with_retry (either `_refine_with_retry = mio.refine_with_retry` OR a
+# thin wrapper that forwards), so build_spill_scenario / build_doublet_base call
+# the SAME promoted logic.  The acceptance point is DELEGATION: these tests must
+# FAIL while the divergent private copy still lives in transport_base_model, and
+# pass for BOTH accepted re-export forms.
 # ===========================================================================
-def test_transport_reexports_helper_attribute():
-    assert hasattr(tbm, "_refine_with_retry"), (
-        "transport_base_model must keep a module attribute _refine_with_retry "
-        "(the promoted helper) for build_spill_scenario/build_doublet_base"
+def test_transport_delegates_to_promoted_helper(monkeypatch):
+    # Never touch real refinement: neutralize the low-level builder up front so
+    # that IF a leftover private copy still ran its own radius-walk, it would use
+    # THIS fake (and, crucially, would NOT touch the promoted-helper spy below).
+    leftover_builder = _make_fake(lambda i, rr: object())
+    monkeypatch.setattr(mio, "build_refined_gwf_model", leftover_builder)
+
+    # Accepted form A — pure re-export: the module attribute IS the promoted
+    # helper object itself.  Identity settles delegation with nothing more to do.
+    if tbm._refine_with_retry is getattr(mio, "refine_with_retry", object()):
+        return
+
+    # Accepted form B — thin wrapper: it must FORWARD to mio.refine_with_retry.
+    # Spy on the promoted helper and prove the transport attribute routes through
+    # it (returning the spy's value), rather than executing an independent body.
+    marker = object()
+    spy_calls = []
+
+    def spy(*args, **kwargs):
+        spy_calls.append((args, kwargs))
+        return marker
+
+    monkeypatch.setattr(mio, "refine_with_retry", spy, raising=False)
+
+    out = tbm._refine_with_retry(COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws")
+
+    assert spy_calls, (
+        "transport_base_model._refine_with_retry must delegate to "
+        "mio.refine_with_retry, not keep its own radius-walk body"
     )
-    assert callable(tbm._refine_with_retry)
+    assert out is marker, "the wrapper must forward the promoted helper's return"
+    assert leftover_builder.calls == [], (
+        "delegating wrapper must not call build_refined_gwf_model itself"
+    )
 
 
-@pytest.mark.parametrize("caller_name", ["refine_with_retry", "_refine_with_retry"])
-def test_promoted_and_transport_helpers_share_behavior(monkeypatch, caller_name):
-    # Same fake scenario driven through BOTH the public mio helper and the
-    # transport re-export must yield identical control flow.
-    caller = (mio.refine_with_retry if caller_name == "refine_with_retry"
-              else tbm._refine_with_retry)
+def test_transport_has_no_duplicate_retry_body():
+    # The retry BODY (the radius loop that calls build_refined_gwf_model) must
+    # live only in the promoted helper.  A pure re-export points its source at
+    # model_io_utils; a thin wrapper lives in transport_base_model but must NOT
+    # reference build_refined_gwf_model (i.e. must not re-implement the walk).
+    fn = tbm._refine_with_retry
+    src_file = os.path.basename(inspect.getsourcefile(fn) or "")
 
-    sentinel = object()
+    if src_file == "model_io_utils.py":
+        # pure re-export: same object as the promoted helper
+        assert fn is mio.refine_with_retry
+        return
 
-    def behavior(i, rr):
-        # succeed on the 2nd radius (62.0)
-        return sentinel if i == 1 else RuntimeError("retry")
-
-    fake = _make_fake(behavior)
-    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
-
-    res, radius = caller(COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws")
-
-    assert res is sentinel
-    assert radius == 62.0
-    assert [c["refine_radius"] for c in fake.calls] == [70.0, 62.0]
-    assert _basenames(fake) == ["rg0", "rg1"]
-
-
-def test_transport_helper_total_failure_matches(monkeypatch):
-    # The transport re-export must also raise RuntimeError on total failure.
-    fake = _make_fake(lambda i, rr: ValueError("still-boom"))
-    monkeypatch.setattr(mio, "build_refined_gwf_model", fake)
-
-    with pytest.raises(RuntimeError) as exc:
-        tbm._refine_with_retry(
-            COARSE, BOUNDARY, RIVER, POINTS, HEADS, "/ws",
-            refine_radii=(70.0, 62.0))
-    assert "still-boom" in str(exc.value)
+    assert src_file == "transport_base_model.py", (
+        f"unexpected source file for the transport helper: {src_file!r}"
+    )
+    src = inspect.getsource(fn)
+    assert "build_refined_gwf_model" not in src, (
+        "transport_base_model must not keep its own copy of the retry body "
+        "(no direct build_refined_gwf_model call); delegate to the promoted "
+        "mio.refine_with_retry instead"
+    )


### PR DESCRIPTION
## Gate

Moves `_refine_with_retry()` from private method in `transport_base_model` to public utility in `model_io_utils`, enabling reuse across flow and transport modules.

## Conformance

- ✅ Public function in `model_io_utils.refine_with_retry()` (60 line import, delegation, +retry logic)
- ✅ `transport_base_model` updated to call public utility (36 lines removed, duplicate eliminated)
- ✅ Acceptance tests: 2 LOCKED criteria + delegation + no-duplicate-body (298 lines, all passing)
- ✅ No breaking changes to transport API