### PR TITLE
M2b determinism gate: allow deterministic fallback (real-Hub fix)

### DIFF
--- a/_SUPPORT/src/scripts/jupyterhub_refine_reliability_gen.py
+++ b/_SUPPORT/src/scripts/jupyterhub_refine_reliability_gen.py
@@ -14,9 +14,15 @@ that legacy diagnostic is left untouched.
 
 Scope (M2b-1): the PURE determinism-check core.
     - ``run_group_determinism_check`` -- reruns a caller-supplied runner and
-      verifies exact agreement on the grid/BC structure (ncpl, active-cell
-      count, chd/riv/wel cellids, well_cells) and on the refine radius, and
-      enforces that no run silently fell back to a wider retry radius.
+      verifies exact agreement, across EVERY rerun, on the grid/BC structure
+      (ncpl, active-cell count, chd/riv/wel cellids, well_cells) and on the
+      refine radius actually used. A deterministic fallback (every rerun
+      independently lands on the SAME non-first retry radius, producing the
+      identical mesh) PASSES and is safe to freeze; only genuine divergence
+      across reruns -- or a runner that raises, e.g. a SIGILL child death --
+      fails. The informational ``first_radius_fallback`` field on the result
+      surfaces (without gating) whether the agreed-upon radius was a
+      fallback.
     - ``assert_flow_specs_equal`` -- exact freeze/load (or rerun) equivalence
       helper for a flow spec, via ``np.array_equal``.
 
@@ -41,7 +47,8 @@ Scope (M2b-2): subprocess-isolated runner + freeze-on-PASS orchestration.
       canonical spec (via ``model_io_utils.freeze_flow_spec``, which itself
       calls ``validate_flow_spec`` and never writes on an invalid spec) to
       ``<meshes_dir>/group<N>_flow.npz`` + manifest, recording ``group``,
-      ``platform.node()``, best-effort tool versions, and ``radius_used``.
+      ``platform.node()``, best-effort tool versions, ``radius_used``, and
+      the informational ``first_radius_fallback`` flag.
 
 Scope (M2b-3): the CLI entry point.
     - ``main(argv=None) -> int`` -- argparse CLI wiring ``--groups`` (comma
@@ -58,8 +65,9 @@ Scope (M2b-3): the CLI entry point.
       optionally freezes the PASSing spec via
       ``freeze_group_flow_artifact`` when ``--freeze`` is given, and writes
       one machine-readable JSON report entry per group to ``--out``
-      (determinism status/reason, freeze status, node, tool versions, and
-      radius). Exits nonzero ONLY when ``--require-green-style`` is set and
+      (determinism status/reason, freeze status, node, tool versions, radius,
+      and the informational ``first_radius_fallback`` flag). Exits nonzero
+      ONLY when ``--require-green-style`` is set and
       at least one selected group failed determinism; without that flag a
       failing group is reported but the run still exits 0. The model-loading
       / subprocess body only ever executes inside ``main()`` -- importing
@@ -120,8 +128,13 @@ RETRY_RADII = (70.0, 62.0, 78.0, 56.0, 84.0)
 
 def _was_retried(radius_used: float) -> bool:
     """True iff *radius_used* differs from ``RETRY_RADII[0]`` -- i.e. the
-    refinement fell back to a wider retry radius and is therefore NOT safe
-    to freeze as a pinned artifact."""
+    refinement fell back to a wider retry radius.
+
+    PURELY INFORMATIONAL (see ``first_radius_fallback`` on the
+    ``run_group_determinism_check`` result): a deterministic fallback is
+    safe to freeze, so this no longer gates PASS/FAIL -- it just lets an
+    instructor see, from the report/manifest, that a group froze at a
+    fallback radius rather than the first-attempted one."""
     return not math.isclose(float(radius_used), RETRY_RADII[0])
 
 
@@ -140,7 +153,9 @@ def _fail(group: Group, radius_used: Any = None, reason: str = "") -> Dict[str, 
     (never ``float('nan')``) when no real radius is available -- e.g. a
     runner-exception path that never got as far as reading a spec -- so
     that a NaN can never leak into a JSON report or a freeze call. When
-    ``None`` the ``radius_used`` key is simply omitted."""
+    ``None`` the ``radius_used`` (and ``first_radius_fallback``) keys are
+    simply omitted; when a radius IS known, ``first_radius_fallback`` is
+    included alongside it (informational only -- see ``_was_retried``)."""
     result: Dict[str, Any] = {
         "status": "FAIL",
         "group": int(group),
@@ -148,6 +163,7 @@ def _fail(group: Group, radius_used: Any = None, reason: str = "") -> Dict[str, 
     }
     if radius_used is not None:
         result["radius_used"] = float(radius_used)
+        result["first_radius_fallback"] = _was_retried(radius_used)
     return result
 
 
@@ -163,13 +179,19 @@ def run_group_determinism_check(
     a pure comparison over whatever the runner returns.
 
     A run is only reported PASS if, across every rerun:
-      - ``retried`` is False (no run silently fell back to a wider radius);
       - ``radius_used`` is identical;
       - ``ncpl`` is identical;
       - the active-cell count (``sum(idomain != 0)``) is identical;
       - ``chd_cellid`` / ``riv_cellid`` / ``wel_cellid`` are identical
         (element-wise, order-sensitive);
       - ``well_cells`` is identical.
+
+    A deterministic fallback (every rerun lands on the SAME non-first
+    radius, producing the identical mesh) PASSES and is safe to freeze;
+    only genuine divergence across reruns -- or a runner that raises, e.g.
+    a SIGILL child death -- fails. ``retried`` is therefore NOT part of the
+    gate; it only feeds the informational ``first_radius_fallback`` field
+    (see ``_was_retried``), which never affects the PASS/FAIL verdict.
 
     Otherwise FAIL, naming the first divergence found.
 
@@ -187,7 +209,10 @@ def run_group_determinism_check(
     -------
     dict
         ``status`` ("PASS"/"FAIL"), ``group``, ``reason`` (empty on PASS),
-        ``radius_used`` (from the first run), and ``reruns``.
+        ``radius_used`` (from the first run, when known),
+        ``first_radius_fallback`` (informational -- True iff ``radius_used``
+        is not ``RETRY_RADII[0]``; never gates PASS/FAIL), and ``reruns``
+        (PASS only).
     """
     if reruns < 1:
         raise ValueError(f"reruns must be >= 1, got {reruns!r}")
@@ -202,15 +227,6 @@ def run_group_determinism_check(
 
     spec0, radius0, _ = runs[0]
     radius0 = float(radius0)
-
-    for i, (_spec, _radius, retried) in enumerate(runs):
-        if retried:
-            return _fail(
-                group,
-                radius0,
-                f"run {i} reported a retried/fallback refinement "
-                "(retried=True); a first-radius fallback is not safe to freeze",
-            )
 
     for i, (_spec, radius, _retried) in enumerate(runs[1:], start=1):
         if float(radius) != radius0:
@@ -263,6 +279,7 @@ def run_group_determinism_check(
         "group": int(group),
         "reason": "",
         "radius_used": radius0,
+        "first_radius_fallback": _was_retried(radius0),
         "reruns": reruns,
     }
 
@@ -661,7 +678,8 @@ def subprocess_refine_runner(
 # =============================================================================
 
 def freeze_group_flow_artifact(
-    spec: Dict[str, Any], *, group: Group, meshes_dir: Any, radius_used: float
+    spec: Dict[str, Any], *, group: Group, meshes_dir: Any, radius_used: float,
+    first_radius_fallback: bool = False,
 ) -> Dict[str, Any]:
     """Freeze *spec* to ``<meshes_dir>/group<N>_flow.npz`` (+ manifest) --
     the canonical PINNED artifact ``model_io_utils.load_pinned_flow_model``
@@ -671,7 +689,8 @@ def freeze_group_flow_artifact(
     (``run_group_determinism_check``); this function does not itself gate
     on that -- it just refuses to write anything for an invalid spec
     (``model_io_utils.freeze_flow_spec`` calls ``validate_flow_spec`` before
-    writing).
+    writing). A PASS may itself be a deterministic fallback (see
+    ``first_radius_fallback``) -- that is safe to freeze.
 
     Parameters
     ----------
@@ -684,13 +703,18 @@ def freeze_group_flow_artifact(
         Destination directory (created if missing).
     radius_used : float
         The refine radius that produced *spec*; recorded in the manifest.
+    first_radius_fallback : bool, optional
+        Informational flag (from the determinism-check result) recording
+        whether *radius_used* was a fallback (not the first-attempted)
+        radius. Purely for instructor visibility in the manifest; does not
+        affect freezing. Default False.
 
     Returns
     -------
     dict
         The manifest that was written (includes ``group``,
-        ``platform.node()``, best-effort tool ``versions``, and
-        ``radius_used`` alongside the array hashes).
+        ``platform.node()``, best-effort tool ``versions``, ``radius_used``,
+        and ``first_radius_fallback`` alongside the array hashes).
 
     Raises
     ------
@@ -705,6 +729,7 @@ def freeze_group_flow_artifact(
         "group": int(group),
         "node": platform.node(),
         "radius_used": float(radius_used),
+        "first_radius_fallback": bool(first_radius_fallback),
         "versions": _best_effort_versions(),
     }
     return mio.freeze_flow_spec(spec, npz_path, caller_fields=caller_fields)
@@ -870,6 +895,7 @@ def main(argv=None) -> int:
             spec = calls[0][0]
             manifest = freeze_group_flow_artifact(
                 spec, group=group, meshes_dir=meshes_dir, radius_used=entry["radius_used"],
+                first_radius_fallback=entry.get("first_radius_fallback", False),
             )
             entry["manifest"] = manifest
             frozen = True

--- a/_SUPPORT/tests/test_refine_reliability_gen_script.py
+++ b/_SUPPORT/tests/test_refine_reliability_gen_script.py
@@ -21,10 +21,14 @@ below lives at its own path so the legacy diagnostic survives:
   * ``run_group_determinism_check(group, runner, *, reruns=5) -> dict``
         PURE orchestration. Calls ``runner(group)`` ``reruns`` times; each call
         returns ``(spec_dict, radius_used, retried_bool)``. Reports PASS only if
-        every rerun agrees EXACTLY on ncpl, active-cell count, and every cellid
-        array (chd/riv/wel cellid + well_cells), the radius is identical, and
-        retried is False on every run. Else FAIL naming the first divergence.
-        Contains NO MODFLOW and NO subprocess.
+        every rerun agrees EXACTLY on ncpl, active-cell count, every cellid
+        array (chd/riv/wel cellid + well_cells), and the radius. A
+        DETERMINISTIC fallback -- every rerun independently lands on the SAME
+        non-first retry radius, producing the identical mesh -- PASSES and is
+        safe to freeze; ``retried`` no longer gates the verdict, it only feeds
+        the informational ``first_radius_fallback`` result field. Only genuine
+        divergence across reruns (or a runner that raises) FAILs, naming the
+        first divergence. Contains NO MODFLOW and NO subprocess.
 
   * ``subprocess_refine_runner(group, *, mother_model, work_dir) -> tuple``
         REAL runner. Runs the refinement in a FRESH SUBPROCESS and returns
@@ -200,6 +204,9 @@ def test_determinism_pass_on_identical_runs():
     assert not result.get("reason"), "PASS must have no divergence reason"
     assert float(result["radius_used"]) == 70.0
     assert int(result["group"]) == 3
+    assert result["first_radius_fallback"] is False, (
+        "the first RETRY_RADII entry must NOT be flagged as a fallback"
+    )
 
 
 def test_determinism_calls_runner_exactly_reruns_times_with_group():
@@ -226,28 +233,42 @@ def test_determinism_is_pure_no_subprocess(monkeypatch):
     assert status_of(result) == "PASS"
 
 
-def test_determinism_fail_on_retry_fallback():
-    # Any retried=True on any run means a first-radius fallback -> not freezable.
-    runner = SeqRunner([
-        (make_spec(), 70.0, False),
-        (make_spec(), 70.0, True),   # fallback fired here
-        (make_spec(), 70.0, False),
-    ])
+def test_determinism_pass_on_deterministic_fallback():
+    """A DETERMINISTIC fallback -- every rerun independently lands on the
+    SAME non-first retry radius, producing the identical mesh -- is safe to
+    freeze and must PASS. This supersedes the old zero-fallback rule: the
+    JupyterHub run proved a group can deterministically fall back from
+    radius 70 -> 62 (a Triangle boundary-clip abort caught by
+    refine_with_retry, not intermittent nondeterminism -- 8/8 independent
+    samples gave radius=62), and that reproducible mesh is freezable.
+    `first_radius_fallback` surfaces this informationally without gating
+    the verdict; genuine divergence across reruns still FAILs (see
+    test_determinism_fail_on_differing_radius below)."""
+    fallback_radius = rc.RETRY_RADII[1]
+    runner = const_runner(radius=fallback_radius, retried=True)
     result = rc.run_group_determinism_check(2, runner, reruns=3)
-    assert status_of(result) == "FAIL"
-    reason = (result.get("reason") or "").lower()
-    assert reason, "FAIL must name a reason"
-    assert ("retr" in reason) or ("fallback" in reason), f"reason should name the fallback: {reason!r}"
+    assert status_of(result) == "PASS"
+    assert not result.get("reason"), "PASS must have no divergence reason"
+    assert float(result["radius_used"]) == fallback_radius
+    assert result["first_radius_fallback"] is True, (
+        "first_radius_fallback must surface the fallback informationally"
+    )
 
 
 def test_determinism_fail_on_differing_radius():
+    """Genuine nondeterminism -- reruns landing on DIFFERENT radii -- must
+    still FAIL even though a deterministic fallback now PASSes (see
+    test_determinism_pass_on_deterministic_fallback above)."""
     runner = SeqRunner([
         (make_spec(), 70.0, False),
-        (make_spec(), 62.0, False),  # radius walked
+        (make_spec(), 62.0, False),  # radius walked -- differs from run 0
     ])
     result = rc.run_group_determinism_check(4, runner, reruns=2)
     assert status_of(result) == "FAIL"
     assert "radius" in (result.get("reason") or "").lower()
+    assert "first_radius_fallback" in result, (
+        "the informational flag must still be reported on a FAIL where a radius is known"
+    )
 
 
 def test_determinism_fail_on_differing_ncpl():
@@ -347,13 +368,15 @@ def test_subprocess_runner_derives_retried_false_at_first_radius(tmp_path, monke
     assert retried is False
 
 
-def test_determinism_check_fails_on_derived_retried_via_real_runner(tmp_path, monkeypatch):
+def test_determinism_check_passes_on_derived_retried_true_via_real_runner(tmp_path, monkeypatch):
     """End-to-end through the REAL `subprocess_refine_runner` (driven by the
     AGM_FAKE_SPEC_NPZ hook, so still MODFLOW-free): a frozen spec whose
-    `refine_radius_used` is a fallback radius must make
-    `run_group_determinism_check` FAIL on the zero-fallback rule -- proving
-    `retried` is correctly derived AND enforced end-to-end, with no manifest
-    'retried' field involved anywhere in the chain."""
+    `refine_radius_used` is a fallback radius, reproduced IDENTICALLY across
+    every rerun (the fake hook always returns the same frozen spec), is a
+    DETERMINISTIC fallback and must PASS -- superseding the old zero-fallback
+    rule. Proves `retried`/`first_radius_fallback` is correctly derived and
+    surfaced WITHOUT gating the verdict, with no manifest 'retried' field
+    involved anywhere in the chain."""
     fallback_radius = rc.RETRY_RADII[2]
     npz = freeze_synthetic_spec(
         tmp_path / "fake", "fake_spec.npz", refine_radius_used=fallback_radius
@@ -366,15 +389,18 @@ def test_determinism_check_fails_on_derived_retried_via_real_runner(tmp_path, mo
         )
 
     result = rc.run_group_determinism_check(9, runner, reruns=2)
-    assert status_of(result) == "FAIL"
-    reason = (result.get("reason") or "").lower()
-    assert ("retr" in reason) or ("fallback" in reason), f"reason should name the fallback: {reason!r}"
+    assert status_of(result) == "PASS"
+    assert float(result["radius_used"]) == fallback_radius
+    assert result["first_radius_fallback"] is True, (
+        "a deterministic fallback must still surface first_radius_fallback=True informationally"
+    )
 
 
 def test_determinism_check_passes_on_derived_retried_false_via_real_runner(tmp_path, monkeypatch):
-    """Positive mirror of the fallback-FAIL test above: a spec frozen at
-    `RETRY_RADII[0]` derives retried=False and, being identical across
-    reruns (the fake hook always returns the same frozen spec), PASSes."""
+    """Positive mirror of the fallback-PASS test above: a spec frozen at
+    `RETRY_RADII[0]` derives retried=False / first_radius_fallback=False
+    and, being identical across reruns (the fake hook always returns the
+    same frozen spec), PASSes."""
     npz = freeze_synthetic_spec(
         tmp_path / "fake", "fake_spec.npz", refine_radius_used=rc.RETRY_RADII[0]
     )
@@ -387,6 +413,7 @@ def test_determinism_check_passes_on_derived_retried_false_via_real_runner(tmp_p
 
     result = rc.run_group_determinism_check(9, runner, reruns=2)
     assert status_of(result) == "PASS"
+    assert result["first_radius_fallback"] is False
 
 
 def test_subprocess_runner_actually_spawns_a_fresh_child(tmp_path, monkeypatch):


### PR DESCRIPTION
First JupyterHub run showed group 0's mesh deterministically falls back 70m->62m (Triangle boundary-clip, caught exception — not SIGILL; 8/8 samples identical). The zero-fallback gate wrongly rejected this reproducible mesh. Now: PASS iff all reruns produce the identical mesh (radius+ncpl+cellids); deterministic fallback is allowed and freezable; genuine nondeterminism still fails. Informational first_radius_fallback flag added. 595 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)